### PR TITLE
Update domain_access to work with drupal beta6, fix domain id references

### DIFF
--- a/domain/domain.module
+++ b/domain/domain.module
@@ -206,6 +206,7 @@ function domain_required_fields() {
 
 /**
  * Returns the current domain record.
+ * @return Domain
  */
 function domain_get_domain() {
   $domain = Drupal::service('domain.manager');

--- a/domain/domain.routing.yml
+++ b/domain/domain.routing.yml
@@ -17,7 +17,7 @@ domain.add:
   requirements:
     _permission: "create domains"
 
-domain.edit:
+entity.domain.edit_form:
   path: '/admin/structure/domain/edit/{domain}'
   defaults:
     _entity_form: domain.edit
@@ -27,7 +27,7 @@ domain.edit:
   requirements:
     _entity_access: domain.update
 
-domain.delete:
+entity.domain.delete_form:
   path: '/admin/structure/domain/delete/{domain}'
   defaults:
     _entity_form: domain.delete

--- a/domain/src/DomainListBuilder.php
+++ b/domain/src/DomainListBuilder.php
@@ -104,7 +104,7 @@ class DomainListBuilder extends DraggableListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     $row['label'] = $this->getLabel($entity);
-    $row['hostname'] = array('#markup' => l($entity->hostname, $entity->url));
+    $row['hostname'] = array('#markup' => _l($entity->hostname, $entity->url));
     if ($entity->isActive()) {
       $row['hostname']['#prefix'] = '<strong>';
       $row['hostname']['#suffix'] = '</strong>';

--- a/domain/src/DomainListBuilder.php
+++ b/domain/src/DomainListBuilder.php
@@ -104,7 +104,7 @@ class DomainListBuilder extends DraggableListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     $row['label'] = $this->getLabel($entity);
-    $row['hostname'] = array('#markup' => _l($entity->hostname, $entity->url));
+    $row['hostname'] = array('#markup' => l($entity->hostname, $entity->url));
     if ($entity->isActive()) {
       $row['hostname']['#prefix'] = '<strong>';
       $row['hostname']['#suffix'] = '</strong>';

--- a/domain/src/Entity/Domain.php
+++ b/domain/src/Entity/Domain.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\domain\Entity;
 
+use Drupal\Component\Utility\Unicode;
 use Drupal\domain\DomainInterface;
 use Drupal\Core\Config\Entity\ConfigEntityBase;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -192,7 +193,7 @@ class Domain extends ConfigEntityBase implements DomainInterface {
       }
     }
     // Check for lower case.
-    if ($hostname != drupal_strtolower($hostname)) {
+    if ($hostname != Unicode::strtolower($hostname)) {
       $error_list[] = t('Only lower-case characters are allowed.');
     }
     // Check for 'www' prefix if redirection / handling is enabled under global domain settings.

--- a/domain/src/Form/DomainDeleteForm.php
+++ b/domain/src/Form/DomainDeleteForm.php
@@ -43,7 +43,7 @@ class DomainDeleteForm extends EntityConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
     drupal_set_message($this->t('Domain %label has been deleted.', array('%label' => $this->entity->label())));
-    watchdog('domain', 'Domain %label has been deleted.', array('%label' => $this->entity->label()), WATCHDOG_NOTICE);
+    \Drupal::logger('domain')->notice('Domain %label has been deleted.', array('%label' => $this->entity->label()));
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -10,7 +10,7 @@ use Drupal\domain\DomainInterface;
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\NodeType;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxy;
 use Drupal\user\UserInterface;
 
 /**
@@ -26,7 +26,7 @@ define('DOMAIN_ACCESS_USER_FIELD', 'field_domain_user');
 /**
  * Implements hook_node_grants().
  */
-function domain_access_node_grants(AccountInterface $account, $op) {
+function domain_access_node_grants(AccountProxy $account, $op) {
   $grants = array();
   $active = domain_get_domain();
   $id = $active->domain_id;
@@ -38,8 +38,9 @@ function domain_access_node_grants(AccountInterface $account, $op) {
   }
 
   // Grants for edit/delete require permissions.
-  if($account instanceof UserInterface) {
-    $user_domains = domain_access_get_entity_values($account, DOMAIN_ACCESS_USER_FIELD);
+  if($account->isAuthenticated()) {
+    $user = entity_load('user', $account->id());
+    $user_domains = domain_access_get_entity_values($user, DOMAIN_ACCESS_USER_FIELD);
     if ($op == 'update' && $account->hasPermission('edit domain content') && isset($user_domains[$id])) {
       $grants['domain_id'][] = $id;
     }
@@ -106,7 +107,8 @@ function domain_access_get_entity_values($entity, $field_name) {
   if (!empty($values)) {
     foreach ($values as $item) {
       if ($target = $item->getValue()) {
-        $list[$target['target_id']] = $target['target_id'];
+        $domain = domain_load($target['target_id']);
+        $list[$domain->domain_id] = $target['target_id'];
       }
     }
   }

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -11,6 +11,7 @@ use Drupal\node\NodeInterface;
 use Drupal\node\Entity\NodeType;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Defines the name of the node access control field.
@@ -25,22 +26,26 @@ define('DOMAIN_ACCESS_USER_FIELD', 'field_domain_user');
 /**
  * Implements hook_node_grants().
  */
-function domain_access_node_grants($op, AccountInterface $account) {
+function domain_access_node_grants(AccountInterface $account, $op) {
   $grants = array();
   $active = domain_get_domain();
-  $id = $active->id();
+  $id = $active->domain_id;
+
   // Grants for view are simple. Use the active domain.
   if ($op == 'view') {
     $grants['domain_id'][] = $id;
     return $grants;
   }
+
   // Grants for edit/delete require permissions.
-  $user_domains = domain_access_get_entity_values($account, DOMAIN_ACCESS_USER_FIELD);
-  if ($op == 'update' && $account->hasPermission('edit domain content') && isset($account_domains[$id])) {
-    $grants['domain_id'][] = $id;
-  }
-  if ($op == 'delete' && $account->hasPermission('delete domain content') && isset($account_domains[$id])) {
-    $grants['domain_id'][] = $id;
+  if($account instanceof UserInterface) {
+    $user_domains = domain_access_get_entity_values($account, DOMAIN_ACCESS_USER_FIELD);
+    if ($op == 'update' && $account->hasPermission('edit domain content') && isset($user_domains[$id])) {
+      $grants['domain_id'][] = $id;
+    }
+    if ($op == 'delete' && $account->hasPermission('delete domain content') && isset($user_domains[$id])) {
+      $grants['domain_id'][] = $id;
+    }
   }
 
   return $grants;
@@ -50,6 +55,7 @@ function domain_access_node_grants($op, AccountInterface $account) {
  * Implements hook_node_access_records().
  */
 function domain_access_node_access_records(NodeInterface $node) {
+  $grants = array();
   foreach (domain_access_get_entity_values($node, DOMAIN_ACCESS_NODE_FIELD) as $value) {
     if ($domain = domain_load($value)) {
       $grants[] = array(

--- a/domain_access/src/DomainAccessPermissions.php
+++ b/domain_access/src/DomainAccessPermissions.php
@@ -7,6 +7,7 @@
 namespace Drupal\domain_access;
 
 use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeTypeInterface;
 
 /**
  * Dynamic permissions class for Domain Access.
@@ -63,17 +64,19 @@ class DomainAccessPermissions {
    * @return array
    *   An array of permission names and descriptions.
    */
-  function nodePermissions($type) {
+  function nodePermissions(NodeTypeInterface $type) {
     // Build standard list of node permissions for this type.
+    $typeId = $type->getEntityTypeId();
+    $typeLabel = $type->label();
     $perms = array(
-      "create $type->type content on assigned domains" => array(
-        'title' => t('%type_name: Create new content on assigned domains', array('%type_name' => $type->name)),
+      "create $typeId content on assigned domains" => array(
+        'title' => t('%type_name: Create new content on assigned domains', array('%type_name' => $typeLabel)),
       ),
-      "update $type->type content on assigned domains" => array(
-        'title' => t('%type_name: Edit any content on assigned domains', array('%type_name' => $type->name)),
+      "update $typeId content on assigned domains" => array(
+        'title' => t('%type_name: Edit any content on assigned domains', array('%type_name' => $typeLabel)),
       ),
-      "delete $type->type content on assigned domains" => array(
-        'title' => t('%type_name: Delete any content on assigned domains', array('%type_name' => $type->name)),
+      "delete $typeId content on assigned domains" => array(
+        'title' => t('%type_name: Delete any content on assigned domains', array('%type_name' => $typeLabel)),
       ),
     );
 


### PR DESCRIPTION
Some updates like rename routes, or replace watchdog are just changes according to the Drupal 8 API. 

Since the grant is a numeric id, I had to change some code in domain_access_node_grants() to return an valid array. 
