### PR TITLE
Fix domain id references

### DIFF
--- a/domain/src/DomainForm.php
+++ b/domain/src/DomainForm.php
@@ -30,7 +30,7 @@ class DomainForm extends EntityForm {
     }
     $form['domain_id'] = array(
       '#type' => 'value',
-      '#value' => $domain->id(),
+      '#value' => $domain->getDomainId(),
     );
     $form['hostname'] = array(
       '#type' => 'textfield',

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -38,15 +38,13 @@ function domain_access_node_grants(AccountProxy $account, $op) {
   }
 
   // Grants for edit/delete require permissions.
-  if($account->isAuthenticated()) {
-    $user = entity_load('user', $account->id());
-    $user_domains = domain_access_get_entity_values($user, DOMAIN_ACCESS_USER_FIELD);
-    if ($op == 'update' && $account->hasPermission('edit domain content') && isset($user_domains[$id])) {
-      $grants['domain_id'][] = $id;
-    }
-    if ($op == 'delete' && $account->hasPermission('delete domain content') && isset($user_domains[$id])) {
-      $grants['domain_id'][] = $id;
-    }
+  $user = entity_load('user', $account->id());
+  $user_domains = domain_access_get_entity_values($user, DOMAIN_ACCESS_USER_FIELD);
+  if ($op == 'update' && $account->hasPermission('edit domain content') && isset($user_domains[$id])) {
+    $grants['domain_id'][] = $id;
+  }
+  if ($op == 'delete' && $account->hasPermission('delete domain content') && isset($user_domains[$id])) {
+    $grants['domain_id'][] = $id;
   }
 
   return $grants;

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -5,12 +5,13 @@
  * Domain-based access control for content.
  */
 
-use Drupal\domain\DomainNegotiator;
+use Drupal\domain\DomainManager;
 use Drupal\domain\DomainInterface;
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\NodeType;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\user\UserInterface;
 
 /**
  * Defines the name of the node access control field.
@@ -25,22 +26,27 @@ define('DOMAIN_ACCESS_USER_FIELD', 'field_domain_user');
 /**
  * Implements hook_node_grants().
  */
-function domain_access_node_grants($op, AccountInterface $account) {
+function domain_access_node_grants(AccountProxy $account, $op) {
   $grants = array();
   $active = domain_get_domain();
-  $id = $active->id();
+  $id = $active->getDomainId();
+
   // Grants for view are simple. Use the active domain.
   if ($op == 'view') {
     $grants['domain_id'][] = $id;
     return $grants;
   }
+
   // Grants for edit/delete require permissions.
-  $user_domains = domain_access_get_entity_values($account, DOMAIN_ACCESS_USER_FIELD);
-  if ($op == 'update' && $account->hasPermission('edit domain content') && isset($account_domains[$id])) {
-    $grants['domain_id'][] = $id;
-  }
-  if ($op == 'delete' && $account->hasPermission('delete domain content') && isset($account_domains[$id])) {
-    $grants['domain_id'][] = $id;
+  if($account->isAuthenticated()) {
+    $user = entity_load('user', $account->id());
+    $user_domains = domain_access_get_entity_values($user, DOMAIN_ACCESS_USER_FIELD);
+    if ($op == 'update' && $account->hasPermission('edit domain content') && isset($user_domains[$id])) {
+      $grants['domain_id'][] = $id;
+    }
+    if ($op == 'delete' && $account->hasPermission('delete domain content') && isset($user_domains[$id])) {
+      $grants['domain_id'][] = $id;
+    }
   }
 
   return $grants;
@@ -50,6 +56,7 @@ function domain_access_node_grants($op, AccountInterface $account) {
  * Implements hook_node_access_records().
  */
 function domain_access_node_access_records(NodeInterface $node) {
+  $grants = array();
   foreach (domain_access_get_entity_values($node, DOMAIN_ACCESS_NODE_FIELD) as $value) {
     if ($domain = domain_load($value)) {
       $grants[] = array(
@@ -100,7 +107,8 @@ function domain_access_get_entity_values($entity, $field_name) {
   if (!empty($values)) {
     foreach ($values as $item) {
       if ($target = $item->getValue()) {
-        $list[$target['target_id']] = $target['target_id'];
+        $domain = domain_load($target['target_id']);
+        $list[$domain->getDomainId()] = $target['target_id'];
       }
     }
   }


### PR DESCRIPTION
I think this will work. The domain_id was not saved to the database, because in DomainForm the wrong id was accessed. 

domain_access_node_grants also needed some updates, so we can get the domain_id and not the machinename. 
