### PR TITLE
Domain_id datatype error fix

### DIFF
--- a/domain/src/DomainForm.php
+++ b/domain/src/DomainForm.php
@@ -30,7 +30,7 @@ class DomainForm extends EntityForm {
     }
     $form['domain_id'] = array(
       '#type' => 'value',
-      '#value' => $domain->id(),
+      '#value' => $domain->getDomainId(),
     );
     $form['hostname'] = array(
       '#type' => 'textfield',


### PR DESCRIPTION
the id method calls the machine name of the entity which is a string and not an integer, which breaks setting the node_access permissions.
