### PR TITLE
Fix cli node_access_rebuild error

### DIFF
--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -35,6 +35,10 @@ function domain_access_node_grants(AccountInterface $account, $op) {
     $active = domain_default(); 
   }
   
+  if(empty($active)) {
+    return $grants;
+  }
+  
   $id = $active->getDomainId();
   // Grants for view are simple. Use the active domain.
   if ($op == 'view') {

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -31,7 +31,9 @@ function domain_access_node_grants(AccountInterface $account, $op) {
   $grants = array();
   $active = domain_get_domain();
   
-  if(empty($active)){ $active = domain_default(); }
+  if(empty($active)) { 
+    $active = domain_default(); 
+  }
   
   $id = $active->getDomainId();
   // Grants for view are simple. Use the active domain.

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -30,6 +30,9 @@ define('DOMAIN_ACCESS_USER_FIELD', 'field_domain_user');
 function domain_access_node_grants(AccountInterface $account, $op) {
   $grants = array();
   $active = domain_get_domain();
+  
+  if(empty($active)){ $active = domain_default(); }
+  
   $id = $active->getDomainId();
   // Grants for view are simple. Use the active domain.
   if ($op == 'view') {


### PR DESCRIPTION
When you add domains during a drush site install, you need to call node_access_rebuild. This calls domain_access_node_grants, and because the domain_get_domain function is url based you have to create a localhost domain because that is the default. 

To prevent the creation of a domain just because it's the default value, I added an extra check that gets the default domain instead. it doesn't interfere with the permission rebuild via the web interface.
