### PR TITLE
drush domain-delete fails when given a domain argument

### DIFF
--- a/domain/domain.drush.inc
+++ b/domain/domain.drush.inc
@@ -421,6 +421,7 @@ function drush_domain_delete($argument = NULL) {
     if ($domain->isDefault()) {
       return drush_set_error('domain', dt('The primary domain may not be deleted. Use drush domain-default to set a new default domain.'));
     }
+    $domains = [$domain];
   }
   else {
     return;


### PR DESCRIPTION
Currently the following notice is thrown and the respective domain is not deleted:
Invalid argument supplied for foreach() domain.drush.inc:428
