### PR TITLE
Fallback to default domain

### DIFF
--- a/domain/src/DomainNegotiator.php
+++ b/domain/src/DomainNegotiator.php
@@ -62,6 +62,10 @@ class DomainNegotiator implements DomainNegotiatorInterface {
     }
     $this->setHttpHost($httpHost);
     $domain = $this->domainLoader->loadByHostname($httpHost);
+    // Fallback to default domain
+    if (empty($domain)) {
+      $domain = $this->domainLoader->loadDefaultDomain();
+    }
     // If a straight load fails, create a base domain for checking.
     if (empty($domain)) {
       $values = array('hostname' => $httpHost);


### PR DESCRIPTION
For convenience, I assume we should fallback to the default domain. This was not currently working when working on a local machine. Can we fix it this way?
