### PR TITLE
Replaced all calls to negotiateActiveDomain with getActiveDomain. Met…

### DIFF
--- a/domain/src/Access/DomainAccessCheck.php
+++ b/domain/src/Access/DomainAccessCheck.php
@@ -56,7 +56,7 @@ class DomainAccessCheck implements AccessCheckInterface {
    * {@inheritdoc}
    */
   public function access(AccountInterface $account) {
-    $domain = $this->domainNegotiator->negotiateActiveDomain();
+    $domain = $this->domainNegotiator->getActiveDomain();
     // Is the domain allowed?
     // No domain, let it pass.
     if (empty($domain)) {

--- a/domain/src/DomainNegotiator.php
+++ b/domain/src/DomainNegotiator.php
@@ -102,9 +102,9 @@ class DomainNegotiator implements DomainNegotiatorInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Determine the active domain.
    */
-  public function negotiateActiveDomain() {
+  protected function negotiateActiveDomain() {
     $httpHost = $this->negotiateActiveHostname();
     $this->setRequestDomain($httpHost);
     return $this->domain;

--- a/domain/src/DomainNegotiatorInterface.php
+++ b/domain/src/DomainNegotiatorInterface.php
@@ -25,11 +25,6 @@ interface DomainNegotiatorInterface {
   public function setActiveDomain(DomainInterface $domain);
 
   /**
-   * Gets the active domain.
-   */
-  public function negotiateActiveDomain();
-
-  /**
    * Stores the inbound httpHost request.
    */
   public function setHttpHost($httpHost);

--- a/domain/src/DomainNegotiatorInterface.php
+++ b/domain/src/DomainNegotiatorInterface.php
@@ -52,6 +52,6 @@ interface DomainNegotiatorInterface {
   /**
    * Gets the active domain.
    */
-  public function getActiveDomain($rest = FALSE);
+  public function getActiveDomain($reset = FALSE);
 
 }

--- a/domain/src/EventSubscriber/DomainSubscriber.php
+++ b/domain/src/EventSubscriber/DomainSubscriber.php
@@ -60,7 +60,7 @@ class DomainSubscriber implements EventSubscriberInterface {
    */
   public function onKernelRequestDomain(GetResponseEvent $event) {
     $redirect = FALSE;
-    if ($domain = $this->domainNegotiator->negotiateActiveDomain()) {
+    if ($domain = $this->domainNegotiator->getActiveDomain()) {
       $domain_url = $domain->getUrl();
       if ($domain_url) {
         $redirect_type = $domain->getRedirect();

--- a/domain/src/EventSubscriber/DomainSubscriber.php
+++ b/domain/src/EventSubscriber/DomainSubscriber.php
@@ -60,7 +60,7 @@ class DomainSubscriber implements EventSubscriberInterface {
    */
   public function onKernelRequestDomain(GetResponseEvent $event) {
     $redirect = FALSE;
-    if ($domain = $this->domainNegotiator->getActiveDomain()) {
+    if ($domain = $this->domainNegotiator->getActiveDomain(TRUE)) {
       $domain_url = $domain->getUrl();
       if ($domain_url) {
         $redirect_type = $domain->getRedirect();

--- a/domain/src/HttpKernel/DomainPathProcessor.php
+++ b/domain/src/HttpKernel/DomainPathProcessor.php
@@ -50,7 +50,7 @@ class DomainPathProcessor implements OutboundPathProcessorInterface {
   public function processOutbound($path, &$options = array(), Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
     static $active_domain;
     if (!isset($active_domain)) {
-      $active_domain = $this->domainNegotiator->negotiateActiveDomain();
+      $active_domain = $this->domainNegotiator->getActiveDomain();
     }
 
     // Only act on valid internal paths and when a domain loads.


### PR DESCRIPTION
Replaced all calls to negotiateActiveDomain with getActiveDomain.
Method getActiveDomain() uses cached result of negotiateActiveDomain() and is safe for performance.
