### PR TITLE
116 help text to domain overview screen

### DIFF
--- a/domain/domain.module
+++ b/domain/domain.module
@@ -8,6 +8,8 @@
 use Drupal\domain\DomainInterface;
 use Drupal\domain\Entity\Domain;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Config\Config;
 
 /**
  * Implements hook_entity_bundle_info().
@@ -38,5 +40,27 @@ function domain_entity_load(array $entities, $entity_type) {
       $domain->setPath();
       $domain->setUrl();
     }
+  }
+}
+
+/**
+ * Implements hook_help().
+ */
+function domain_help($route_name, RouteMatchInterface $route_match) {
+
+  switch ($route_name) {
+    case 'domain.admin':
+      $domains = \Drupal::service('domain.loader')->loadMultipleSorted(NULL, TRUE);
+      foreach ($domains as $domain) {
+        if ($domain->get('is_default') == 1) {
+          $name = $domain->get('name');
+          //$name = $domain->get('hostname');
+        }
+      }
+      $output = t('<p>The following domains have been created for your site.  The currently active domain
+                   <strong>is shown in boldface</strong>.  You may click on a domain to change the currently active domain.
+                   Your default domain is :name, which will be used for all requests that fail to resolve to a registered
+                   domain.</p>', array(':name' => $name));
+      return $output;
   }
 }

--- a/domain/domain.module
+++ b/domain/domain.module
@@ -9,7 +9,6 @@ use Drupal\domain\DomainInterface;
 use Drupal\domain\Entity\Domain;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Config\Config;
 
 /**
  * Implements hook_entity_bundle_info().

--- a/domain/domain.module
+++ b/domain/domain.module
@@ -49,17 +49,10 @@ function domain_help($route_name, RouteMatchInterface $route_match) {
 
   switch ($route_name) {
     case 'domain.admin':
-      $domains = \Drupal::service('domain.loader')->loadMultipleSorted(NULL, TRUE);
-      foreach ($domains as $domain) {
-        if ($domain->get('is_default') == 1) {
-          $name = $domain->get('name');
-          //$name = $domain->get('hostname');
-        }
-      }
       $output = t('<p>The following domains have been created for your site.  The currently active domain
                    <strong>is shown in boldface</strong>.  You may click on a domain to change the currently active domain.
                    Your default domain is :name, which will be used for all requests that fail to resolve to a registered
-                   domain.</p>', array(':name' => $name));
+                   domain.</p>', array(':name' => \Drupal::service('domain.loader')->loadDefaultDomain()->get('name')));
       return $output;
   }
 }

--- a/domain/src/DomainForm.php
+++ b/domain/src/DomainForm.php
@@ -117,7 +117,13 @@ class DomainForm extends EntityForm {
     else {
       drupal_set_message($this->t('Domain record updated.'));
     }
+
+    if ($domain->isDefault()) {
+      \Drupal\Core\Cache\Cache::invalidateTags(array('rendered'));
+    }
+
     $domain->save();
+
     $form_state->setRedirect('domain.admin');
   }
 

--- a/domain/src/DomainForm.php
+++ b/domain/src/DomainForm.php
@@ -117,13 +117,8 @@ class DomainForm extends EntityForm {
     else {
       drupal_set_message($this->t('Domain record updated.'));
     }
-
-    if ($domain->isDefault()) {
-      \Drupal\Core\Cache\Cache::invalidateTags(array('rendered'));
-    }
-
+    \Drupal\Core\Cache\Cache::invalidateTags(array('rendered'));
     $domain->save();
-
     $form_state->setRedirect('domain.admin');
   }
 


### PR DESCRIPTION
Drupal caches help text, so if the default domain was changed it provides obsolete domain name. 
Probably we need to rebuild cache on DomainListBuilder submitForm. Need suggestion to overcome this.
