### PR TITLE
Remove use of StringTranslationTrait

### DIFF
--- a/domain_content/src/Controller/DomainContentController.php
+++ b/domain_content/src/Controller/DomainContentController.php
@@ -9,15 +9,12 @@ namespace Drupal\domain_content\Controller;
 use Drupal\domain\DomainInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 
 /**
  * Controller routines domain content pages.
  */
 class DomainContentController extends ControllerBase {
-
-  use StringTranslationTrait;
 
   /**
    * Generates a list of content by domain.
@@ -107,7 +104,7 @@ class DomainContentController extends ControllerBase {
   /**
    * Checks that a user can access the internal page for a domain list.
    *
-   * @param AccoutnInterface $account
+   * @param AccountInterface $account
    *   The fully loaded user account.
    * @param DomainInterface $domain
    *   The domain being checked.


### PR DESCRIPTION
When I use module `domain_content` without any cache enabled I get this Strict warning.

```
Strict warning: Drupal\Core\Controller\ControllerBase and Drupal\Core\StringTranslation\StringTranslationTrait define the same property ($stringTranslation)
in the composition of Drupal\domain_content\Controller\DomainContentController. 
This might be incompatible, to improve maintainability consider using accessor methods in traits instead. 
Class was composed in include() (line 127 of ... domain_content/src/Controller/DomainContentController.php).
```

That's because the [ControllerBase](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Controller%21ControllerBase.php/class/ControllerBase/8) class already uses the `StringTranslationTrait` so there is no need to use it once again.

Also, fixes a small typo for the `protected function allowAccess(AccountInterface $account, DomainInterface $domain, $permission)` docblock.
