### PR TITLE
Fix SQL exception raised by domain_access_node_grants

### DIFF
--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -58,12 +58,12 @@ function domain_access_node_grants(AccountInterface $account, $op) {
   }
   elseif ($op == 'update' && $user->hasPermission('edit domain content')) {
     if ($user->hasPermission('publish to any domain') || in_array($id, $user_domains) || !empty($user->get(DOMAIN_ACCESS_ALL_FIELD)->value)) {
-      $grants['domain_id'] = $id;
+      $grants['domain_id'][] = $id;
     }
   }
   elseif ($op == 'delete' && $user->hasPermission('delete domain content')) {
     if ($user->hasPermission('publish to any domain') || in_array($id, $user_domains) || !empty($user->get(DOMAIN_ACCESS_ALL_FIELD)->value)) {
-      $grants['domain_id'] = $id;
+      $grants['domain_id'][] = $id;
     }
   }
   return $grants;


### PR DESCRIPTION
domain_access_node_grants raises "Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL". 
This PR fixes the grants syntax error. 
