### PR TITLE
[WIP] Catch all test fails in Travis CI and fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,4 @@ before_script:
   - until curl -s localhost:8080; do true; done > /dev/null
 
 script:
-  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost:8080 "domain,domain_access,domain_alias,domain_config,domain_source" | tee /tmp/domain-test-results.txt
+  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost:8080 "domain,domain_access,domain_alias,domain_config,domain_source"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
 
 install:
   # Install Drush.
-  - composer global require drush/drush:dev-master
+  - composer global require drush/drush:8.*
   - phpenv rehash
 
   # Create database.

--- a/domain_alias/src/Tests/DomainAliasNegotiatorTest.php
+++ b/domain_alias/src/Tests/DomainAliasNegotiatorTest.php
@@ -7,8 +7,6 @@
 
 namespace Drupal\domain_alias\Tests;
 
-use Drupal\domain\DomainInterface;
-use Drupal\domain_alias\Tests\DomainAliasTestBase;
 
 /**
  * Tests domain alias request negotiation.
@@ -42,6 +40,7 @@ class DomainAliasNegotiatorTest extends DomainAliasTestBase {
     user_role_grant_permissions(DRUPAL_ANONYMOUS_RID, array('administer domains'));
 
     // Test the response of the default home page.
+    /** @var \Drupal\domain\Entity\Domain $domain */
     foreach (\Drupal::service('domain.loader')->loadMultiple() as $domain) {
       if (!isset($alias_domain)) {
         $alias_domain = $domain;

--- a/domain_alias/src/Tests/DomainAliasTestBase.php
+++ b/domain_alias/src/Tests/DomainAliasTestBase.php
@@ -32,14 +32,14 @@ abstract class DomainAliasTestBase extends DomainTestBase {
   /**
    * Creates an alias for testing.
    *
-   * @param Drupal\domain\Entity\Domain $domain
+   * @param \Drupal\domain\DomainInterface $domain
    *   A domain entity.
    * @param string $pattern
    *   An optional alias pattern.
    * @param int $redirect
    *   An optional redirect (301 or 302).
    *
-   * @return Drupal\domain_alias\Entity\DomainAlias
+   * @return \Drupal\domain_alias\Entity\DomainAlias
    *   A domain alias entity.
    */
   public function domainAliasCreateTestAlias(DomainInterface $domain, $pattern = NULL, $redirect = 0) {
@@ -52,7 +52,10 @@ abstract class DomainAliasTestBase extends DomainTestBase {
       'redirect' => $redirect,
     );
     // Replicate the logic for creating machine_name patterns.
-    $values['id'] = str_replace(array('*', '.'), '_', $values['pattern']);
+    // @see ConfigBase::validate()
+    $machine_name = str_replace(array('?', '<', '>', '"', '\'', '/', '\\'), '', $values['pattern']);
+    $values['id'] = str_replace(array('*', '.', ':'), '_', $machine_name);
+
     $alias = \Drupal::entityManager()->getStorage('domain_alias')->create($values);
     $alias->save();
 


### PR DESCRIPTION
Updates .travis.yml with additional `after_script` checking.

Should catch all failing tests.
The reason #213 was not caught is that I missed the submodule from tests when the initial Travis PR went in.
