### PR TITLE
allow users to manage other entities with domains

### DIFF
--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -384,6 +384,11 @@ function domain_access_confirm_fields($entity_type, $bundle) {
       'description' => 'Make this user an editor on all domains.',
     ]
   ];
+
+  //Allow users to manage other entities
+  $moduleHandler = Drupal::moduleHandler();
+  $moduleHandler->alter('domain_access_confirm_fields', $text);
+
   $id = $entity_type . '.' . $bundle . '.' . DOMAIN_ACCESS_FIELD;
 
   if (!$field = \Drupal::entityManager()->getStorage('field_config')->load($id)) {


### PR DESCRIPTION
This allows users to add their own entities to the $text variable, allowing them to manage them according to domains (as is done with user and node). 
