### PR TITLE
Pin drush version to 8.* in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
 
 install:
   # Install Drush.
-  - composer global require drush/drush:dev-master
+  - composer global require drush/drush:8.*
   - phpenv rehash
 
   # Create database.


### PR DESCRIPTION
Looks like `drush/drush:dev-master` now requires a new version of `codegyre/robo` which makes composer fail. (e.g. https://travis-ci.org/agentrickard/domain/jobs/129559245)

Pinning it down to `drush/drush:8.*` brings us back on track
