### PR TITLE
Fix "Call to a member function getEntityTypeId() on null" in DomainSelection.php

### DIFF
--- a/domain/src/Plugin/EntityReferenceSelection/DomainSelection.php
+++ b/domain/src/Plugin/EntityReferenceSelection/DomainSelection.php
@@ -36,13 +36,16 @@ class DomainSelection extends DefaultSelection {
     // modules. Those modules must know what type of entity they are dealing
     // with, so look up the entity type and bundle.
     $info = $query->getMetaData('entity_reference_selection_handler');
-    $context['entity_type'] = $info->configuration['entity']->getEntityTypeId();
-    $context['bundle'] = $info->configuration['entity']->bundle();
 
-    // Load the current user.
-    $account = User::load($this->currentUser->id());
-    // Run the alter hook.
-    $this->moduleHandler->alter('domain_references', $query, $account, $context);
+    if (!empty($info->configuration['entity'])) {
+      $context['entity_type'] = $info->configuration['entity']->getEntityTypeId();
+      $context['bundle'] = $info->configuration['entity']->bundle();
+
+      // Load the current user.
+      $account = User::load($this->currentUser->id());
+      // Run the alter hook.
+      $this->moduleHandler->alter('domain_references', $query, $account, $context);
+    }
 
     return $query;
   }


### PR DESCRIPTION
When the error occurs, `DomainSelection::buildEntityQuery()` is called
twice. The first time `$info->configuration['entity']` is set, the
second time it is NULL

The website encountered an unexpected error. Please try again later.
Error: Call to a member function getEntityTypeId() on null in Drupal\domain\Plugin\EntityReferenceSelection\DomainSelection->buildEntityQuery() (line 49 of modules/domain/domain/src/Plugin/EntityReferenceSelection/DomainSelection.php).

```
domain/domain/src/Plugin/EntityReferenceSelection/DomainSelection.php:48:
array(4) {
  'target_type' =>
  string(6) "domain"
  'handler' =>
  string(14) "default:domain"
  'handler_settings' =>
  array(1) {
    'sort' =>
    array(2) {
      'field' =>
      string(6) "weight"
      'direction' =>
      string(3) "ASC"
    }
  }
  'entity' =>
  class Drupal\user\Entity\User#499 (23) {
  // ...
  }
}
domain/domain/src/Plugin/EntityReferenceSelection/DomainSelection.php:48:
array(4) {
  'target_type' =>
  string(6) "domain"
  'handler' =>
  string(14) "default:domain"
  'handler_settings' =>
  array(1) {
    'sort' =>
    array(2) {
      'field' =>
      string(6) "weight"
      'direction' =>
      string(3) "ASC"
    }
  }
  'entity' =>
  NULL
}
```
