### PR TITLE
Update DOMAIN_ACCESS_* field access implementation and add tests

### DIFF
--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -356,7 +356,7 @@ function domain_access_entity_field_access($operation, FieldDefinitionInterface 
       $access = AccessResult::allowedIfHasPermissions($account, [
         'publish to any domain',
         'publish to any assigned domain',
-      ]);
+      ], 'OR');
     }
 
     // allowedIfHasPermissions returns allowed() or neutral().

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -5,10 +5,11 @@
  * Domain-based access control for content.
  */
 
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 
 /**
@@ -320,7 +321,7 @@ function domain_access_node_create_access(AccountInterface $account, $context, $
   $user_domains = \Drupal::service('domain_access.manager')->getAccessValues($user);
   if (($account->hasPermission('create ' . $entity_bundle . ' content on assigned domains')
       || $account->hasPermission('create domain content'))
-      && in_array($id, $user_domains)) {
+    && in_array($id, $user_domains)) {
     // Note the cache context here!
     return AccessResult::allowed()->addCacheContexts(['user.permissions', 'url.site']);
   }
@@ -329,33 +330,27 @@ function domain_access_node_create_access(AccountInterface $account, $context, $
 }
 
 /**
- * Implements hook_form_node_form_alter().
- *
- * Hides fields that the user cannot access.
+ * Implements hook_entity_field_access().
  */
-function domain_access_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $account = \Drupal::currentUser();
-  if (isset($form[DOMAIN_ACCESS_FIELD])) {
-    $form[DOMAIN_ACCESS_FIELD]['#access'] = ($account->hasPermission('publish to any domain') || $account->hasPermission('publish to any assigned domain'));
+function domain_access_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+  // Hide the domain access fields from the entity add/edit forms
+  // when the user cannot access them.
+  if ($operation != 'edit') {
+    return AccessResult::neutral();
   }
-  if (isset($form[DOMAIN_ACCESS_ALL_FIELD])) {
-    $form[DOMAIN_ACCESS_ALL_FIELD]['#access'] = $account->hasPermission('publish to any domain');
-  }
-}
 
-/**
- * Implements hook_form_user_form_alter().
- *
- * Hides fields that the user cannot access.
- */
-function domain_access_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $account = \Drupal::currentUser();
-  if (isset($form[DOMAIN_ACCESS_FIELD])) {
-    $form[DOMAIN_ACCESS_FIELD]['#access'] = ($account->hasPermission('assign domain editors') || $account->hasPermission('assign editors to any domain'));
+  if ($field_definition->getName() == DOMAIN_ACCESS_FIELD) {
+    $access = AccessResult::allowedIfHasPermissions($account, ['assign domain editors', 'assign editors to any domain'], 'OR');
+
+    if (!$access->isAllowed()) {
+      return AccessResult::forbidden();
+    }
   }
-  if (isset($form[DOMAIN_ACCESS_ALL_FIELD])) {
-    $form[DOMAIN_ACCESS_ALL_FIELD]['#access'] = $account->hasPermission('assign editors to any domain');
+  elseif ($field_definition->getName() == DOMAIN_ACCESS_ALL_FIELD) {
+    return AccessResult::forbiddenIf(!$account->hasPermission('assign editors to any domain'));
   }
+
+  return AccessResult::neutral();
 }
 
 /**

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -11,6 +11,7 @@ use Drupal\node\NodeInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\Entity\User;
 
 /**
  * Defines the name of the node access control field.
@@ -339,15 +340,38 @@ function domain_access_entity_field_access($operation, FieldDefinitionInterface 
     return AccessResult::neutral();
   }
 
-  if ($field_definition->getName() == DOMAIN_ACCESS_FIELD) {
-    $access = AccessResult::allowedIfHasPermissions($account, ['assign domain editors', 'assign editors to any domain'], 'OR');
+  // The entity the field is attached to.
+  $entity = $items->getEntity();
 
+  if ($field_definition->getName() == DOMAIN_ACCESS_FIELD) {
+    if ($entity instanceof User) {
+      $access = AccessResult::allowedIfHasPermissions($account, [
+        'assign domain editors',
+        'assign editors to any domain',
+      ], 'OR');
+    }
+    else {
+      // Treat any other entity as content.
+      $access = AccessResult::allowedIfHasPermissions($account, [
+        'publish to any domain',
+        'publish to any assigned domain',
+      ]);
+    }
+
+    // allowedIfHasPermissions returns allowed() or neutral().
+    // In this case, we want it to be forbidden,
+    // if user doesn't have the permissions above.
     if (!$access->isAllowed()) {
       return AccessResult::forbidden();
     }
   }
   elseif ($field_definition->getName() == DOMAIN_ACCESS_ALL_FIELD) {
-    return AccessResult::forbiddenIf(!$account->hasPermission('assign editors to any domain'));
+    if ($entity instanceof User) {
+      return AccessResult::forbiddenIf(!$account->hasPermission('assign editors to any domain'));
+    }
+
+    // Treat any other entity as content.
+    return AccessResult::forbiddenIf(!$account->hasPermission('publish to any domain'));
   }
 
   return AccessResult::neutral();

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -43,7 +43,7 @@ function domain_access_node_grants(AccountInterface $account, $op) {
   $id = $active->getDomainId();
   // Advanced grants for edit/delete require permissions.
   /** @var \Drupal\user\UserInterface $user */
-  $user = \Drupal::entityManager()->getStorage('user')->load($account->id());
+  $user = \Drupal::entityTypeManager()->getStorage('user')->load($account->id());
   $user_domains = \Drupal::service('domain_access.manager')->getAccessValues($user);
   // Grants for view are simple. Use the active domain and all affiliates.
   // Note that "X to any domain" is a global permission designed for admins.
@@ -274,13 +274,13 @@ function domain_access_node_access(NodeInterface $node, $op, AccountInterface $a
       return AccessResult::allowed()
         ->cachePerPermissions()
         ->cachePerUser()
-        ->cacheUntilEntityChanges($node);
+        ->addCacheableDependency($node);
     }
     if ($account->hasPermission('edit domain content') && $manager->checkEntityAccess($node, $account)) {
       return AccessResult::allowed()
         ->cachePerPermissions()
         ->cachePerUser()
-        ->cacheUntilEntityChanges($node);
+        ->addCacheableDependency($node);
     }
   }
 
@@ -289,13 +289,13 @@ function domain_access_node_access(NodeInterface $node, $op, AccountInterface $a
       return AccessResult::allowed()
         ->cachePerPermissions()
         ->cachePerUser()
-        ->cacheUntilEntityChanges($node);
+        ->addCacheableDependency($node);
     }
     if ($account->hasPermission('delete domain content') && $manager->checkEntityAccess($node, $account)) {
       return AccessResult::allowed()
         ->cachePerPermissions()
         ->cachePerUser()
-        ->cacheUntilEntityChanges($node);
+        ->addCacheableDependency($node);
     }
   }
 
@@ -311,6 +311,7 @@ function domain_access_node_access(NodeInterface $node, $op, AccountInterface $a
 function domain_access_node_create_access(AccountInterface $account, $context, $entity_bundle) {
   // Check to see that we have a valid active domain.
   // Without one, we cannot assert an opinion about access.
+  /** @var \Drupal\domain\DomainInterface $active */
   if ($active = \Drupal::service('domain.negotiator')->getActiveDomain()) {
     $id = $active->getDomainId();
   }
@@ -318,7 +319,7 @@ function domain_access_node_create_access(AccountInterface $account, $context, $
     return AccessResult::neutral();
   }
   // Load the full user record.
-  $user = \Drupal::entityManager()->getStorage('user')->load($account->id());
+  $user = \Drupal::entityTypeManager()->getStorage('user')->load($account->id());
   $user_domains = \Drupal::service('domain_access.manager')->getAccessValues($user);
   if (($account->hasPermission('create ' . $entity_bundle . ' content on assigned domains')
       || $account->hasPermission('create domain content'))
@@ -412,7 +413,7 @@ function domain_access_confirm_fields($entity_type, $bundle) {
   ];
   $id = $entity_type . '.' . $bundle . '.' . DOMAIN_ACCESS_FIELD;
 
-  if (!$field = \Drupal::entityManager()->getStorage('field_config')->load($id)) {
+  if (!$field = \Drupal::entityTypeManager()->getStorage('field_config')->load($id)) {
     $field = array(
       'field_name' => DOMAIN_ACCESS_FIELD,
       'entity_type' => $entity_type,
@@ -427,13 +428,13 @@ function domain_access_confirm_fields($entity_type, $bundle) {
         ),
       ),
     );
-    $field_config = \Drupal::entityManager()->getStorage('field_config')->create($field);
+    $field_config = \Drupal::entityTypeManager()->getStorage('field_config')->create($field);
     $field_config->save();
 
   }
   // Assign the all affiliates field to nodes.
   $id = $entity_type . '.' . $bundle . '.' . DOMAIN_ACCESS_ALL_FIELD;
-  if (!$field = \Drupal::entityManager()->getStorage('field_config')->load($id)) {
+  if (!$field = \Drupal::entityTypeManager()->getStorage('field_config')->load($id)) {
     $field = array(
       'field_name' => DOMAIN_ACCESS_ALL_FIELD,
       'entity_type' => $entity_type,
@@ -443,7 +444,7 @@ function domain_access_confirm_fields($entity_type, $bundle) {
       'description' => $text[$entity_type]['description'],
       'default_value_callback' => 'Drupal\domain_access\DomainAccessManager::getDefaultAllValue',
     );
-    $field_config = \Drupal::entityManager()->getStorage('field_config')->create($field);
+    $field_config = \Drupal::entityTypeManager()->getStorage('field_config')->create($field);
     $field_config->save();
   }
   // Tell the form system how to behave. Default to radio buttons.
@@ -494,8 +495,10 @@ function domain_access_views_data_alter(array &$data) {
  */
 function domain_access_domain_insert($entity) {
   $id = 'domain_access_add_action.' . $entity->id();
-  if (!entity_load('action', $id)) {
-    $action = entity_create('action', array(
+  $controller = \Drupal::entityTypeManager()->getStorage('action');
+  if (!$controller->load($id)) {
+    /** @var \Drupal\system\Entity\Action $action */
+    $action = $controller->create(array(
       'id' => $id,
       'type' => 'node',
       'label' => t('Add selected content to the @label domain', array('@label' => $entity->label())),
@@ -507,8 +510,9 @@ function domain_access_domain_insert($entity) {
     $action->trustData()->save();
   }
   $remove_id = 'domain_access_remove_action.' . $entity->id();
-  if (!entity_load('action', $remove_id)) {
-    $action = entity_create('action', array(
+  if (!$controller->load($remove_id)) {
+    /** @var \Drupal\system\Entity\Action $action */
+    $action = $controller->create(array(
       'id' => $remove_id,
       'type' => 'node',
       'label' => t('Remove selected content from the @label domain', array('@label' => $entity->label())),
@@ -520,8 +524,9 @@ function domain_access_domain_insert($entity) {
     $action->trustData()->save();
   }
   $id = 'domain_access_add_editor_action.' . $entity->id();
-  if (!entity_load('action', $id)) {
-    $action = entity_create('action', array(
+  if (!$controller->load($id)) {
+    /** @var \Drupal\system\Entity\Action $action */
+    $action = $controller->create(array(
       'id' => $id,
       'type' => 'user',
       'label' => t('Add editors to the @label domain', array('@label' => $entity->label())),
@@ -533,8 +538,9 @@ function domain_access_domain_insert($entity) {
     $action->trustData()->save();
   }
   $remove_id = 'domain_access_remove_editor_action.' . $entity->id();
-  if (!entity_load('action', $remove_id)) {
-    $action = entity_create('action', array(
+  if (!$controller->load($remove_id)) {
+    /** @var \Drupal\system\Entity\Action $action */
+    $action = $controller->create(array(
       'id' => $remove_id,
       'type' => 'user',
       'label' => t('Remove editors from the @label domain', array('@label' => $entity->label())),
@@ -551,7 +557,8 @@ function domain_access_domain_insert($entity) {
  * Implements hook_ENTITY_TYPE_delete().
  */
 function domain_access_domain_delete(EntityInterface $entity) {
-  $actions = entity_load_multiple('action', array(
+  $controller = \Drupal::entityTypeManager()->getStorage('action');
+  $actions = $controller->loadMultiple(array(
     'domain_access_add_action.' . $entity->id(),
     'domain_access_remove_action.' . $entity->id(),
     'domain_access_add_editor_action.' . $entity->id(),


### PR DESCRIPTION
This PR
- Changes the access on the `DOMAIN_ACCESS_*` fields to use `hook_entity_field_access()` to cover any entity that have them 
- Adds tests for #217.
  - [x] Test for simple user editing account
  - [x] Test for editing node

Example scenario:
- Domain Access added to existing site
- Not all users are assigned to a domain
- A regular user without the assign domain editors or assign editors to
  any domain permission edits their account (e.g. changes password)
- On save you get an SQL exception. Confirmed fixed by [patch 5](https://www.drupal.org/files/issues/field-schema-2609252-5.patch) from https://www.drupal.org/node/2609252 

Ditto for editing node.
