### PR TITLE
Fix Domain condition crashes blocks regression

### DIFF
--- a/domain/src/Plugin/Condition/Domain.php
+++ b/domain/src/Plugin/Condition/Domain.php
@@ -65,7 +65,7 @@ class Domain extends ConditionPluginBase implements ContainerFactoryPluginInterf
       '#type' => 'checkboxes',
       '#title' => $this->t('When the following domains are active'),
       '#default_value' => $this->configuration['domains'],
-      '#options' => array_map('\Drupal\Component\Utility\Html::checkPlain', \Drupal::service('domain.loader')->loadOptionsList()),
+      '#options' => array_map('\Drupal\Component\Utility\Html::escape', \Drupal::service('domain.loader')->loadOptionsList()),
       '#description' => $this->t('If you select no domains, the condition will evaluate to TRUE for all requests.'),
       '#attached' => array(
         'library' => array(


### PR DESCRIPTION
Fixes #227

Regression introduced in 1ff4051: `SafeMarkup::checkPlain()` accidentally replaced with `Drupal\Component\Utility\Html::checkPlain()` instead of 'Drupal\Component\Utility\Html::escape`

Sorry!
Note to self: better tests!
