### PR TITLE
[BUGFIX #253] Aliasing not working if non default

### DIFF
--- a/domain/src/DomainNegotiator.php
+++ b/domain/src/DomainNegotiator.php
@@ -70,10 +70,6 @@ class DomainNegotiator implements DomainNegotiatorInterface {
       // If the load worked, set an exact match flag for the hook.
       $domain->setMatchType(DOMAIN_MATCH_EXACT);
     }
-    // Fallback to default domain if no match.
-    elseif ($domain = $this->domainLoader->loadDefaultDomain()) {
-      $domain->setMatchType(DOMAIN_MATCH_NONE);
-    }
     // If a straight load fails, create a base domain for checking. This data
     // is required for hook_domain_request_alter().
     else {
@@ -90,6 +86,16 @@ class DomainNegotiator implements DomainNegotiatorInterface {
     $id = $domain->id();
     if (!empty($id)) {
       $this->setActiveDomain($domain);
+    } else {
+      // Fallback to default domain if no match.
+      if ($domain = $this->domainLoader->loadDefaultDomain()) {
+        $this->moduleHandler->alter('domain_request', $domain);
+        $domain->setMatchType(DOMAIN_MATCH_NONE);
+        $id = $domain->id();
+        if (!empty($id)) {
+          $this->setActiveDomain($domain);
+        }
+      }
     }
   }
 

--- a/domain/src/DomainNegotiator.php
+++ b/domain/src/DomainNegotiator.php
@@ -86,15 +86,14 @@ class DomainNegotiator implements DomainNegotiatorInterface {
     $id = $domain->id();
     if (!empty($id)) {
       $this->setActiveDomain($domain);
-    } else {
-      // Fallback to default domain if no match.
-      if ($domain = $this->domainLoader->loadDefaultDomain()) {
-        $this->moduleHandler->alter('domain_request', $domain);
-        $domain->setMatchType(DOMAIN_MATCH_NONE);
-        $id = $domain->id();
-        if (!empty($id)) {
-          $this->setActiveDomain($domain);
-        }
+    }
+    // Fallback to default domain if no match.
+    elseif ($domain = $this->domainLoader->loadDefaultDomain()) {
+      $this->moduleHandler->alter('domain_request', $domain);
+      $domain->setMatchType(DOMAIN_MATCH_NONE);
+      $id = $domain->id();
+      if (!empty($id)) {
+        $this->setActiveDomain($domain);
       }
     }
   }


### PR DESCRIPTION
- PB: aliases defined for a non default domain are not used as the
  hook is called with the default domain.
- FIX: only switch to the default domain if the hook with the
  requested domain returns nothing
