### PR TITLE
221 views access

### DIFF
--- a/domain/domain.services.yml
+++ b/domain/domain.services.yml
@@ -4,6 +4,11 @@ services:
     tags:
       - { name: access_check }
     arguments: ['@domain.negotiator', '@config.factory']
+  access_check.domain_route:
+    class: Drupal\domain\Access\DomainRouteCheck
+    tags:
+      - { name: access_check, applies_to: _domain }
+    arguments: ['@domain.negotiator']
   domain.current_domain_context:
     class: Drupal\domain\ContextProvider\CurrentDomainContext
     arguments: ['@domain.negotiator']

--- a/domain/src/Access/DomainRouteCheck.php
+++ b/domain/src/Access/DomainRouteCheck.php
@@ -13,7 +13,11 @@ use Drupal\domain\DomainNegotiatorInterface;
  *
  * You can specify the '_domain' key on route requirements. If you specify a
  * single domain, users with that domain with have access. If you specify multiple
- * ones you can conjunct them with AND by using a "," and with OR by using "+".
+ * ones you can join them by using "+".
+ *
+ * This access checker is separate from the global check used by inactive
+ * domains. It is expressly for use with Views and other systems that need
+ * to add a domain requirement to a specific route.
  */
 class DomainRouteCheck implements AccessInterface {
 
@@ -35,7 +39,7 @@ class DomainRouteCheck implements AccessInterface {
   }
 
   /**
-   * Checks access.
+   * Checks access to a route with a _domain requirement.
    *
    * @param \Symfony\Component\Routing\Route $route
    *   The route to check against.
@@ -44,6 +48,8 @@ class DomainRouteCheck implements AccessInterface {
    *
    * @return \Drupal\Core\Access\AccessResultInterface
    *   The access result.
+   *
+   * @see Drupal\domain\Plugin\views\access\Domain.php
    */
   public function access(Route $route, AccountInterface $account) {
     // Requirements just allow strings, so this might be a comma separated list.

--- a/domain/src/Access/DomainRouteCheck.php
+++ b/domain/src/Access/DomainRouteCheck.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\domain\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\Routing\Route;
+use Drupal\domain\DomainNegotiatorInterface;
+
+/**
+ * Determines access to routes based on domains.
+ *
+ * You can specify the '_domain' key on route requirements. If you specify a
+ * single domain, users with that domain with have access. If you specify multiple
+ * ones you can conjunct them with AND by using a "," and with OR by using "+".
+ */
+class DomainRouteCheck implements AccessInterface {
+
+  /**
+   * The Domain negotiator.
+   *
+   * @var \Drupal\domain\DomainNegotiatorInterface
+   */
+  protected $domainNegotiator;
+
+  /**
+   * Constructs the object.
+   *
+   * @param DomainNegotiatorInterface $negotiator
+   *   The domain negotiation service.
+   */
+  public function __construct(DomainNegotiatorInterface $negotiator) {
+    $this->domainNegotiator = $negotiator;
+  }
+
+  /**
+   * Checks access.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route to check against.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(Route $route, AccountInterface $account) {
+    // Requirements just allow strings, so this might be a comma separated list.
+    $string = $route->getRequirement('_domain');
+    $domain = $this->domainNegotiator->getActiveDomain();
+    // Since only one domain can be active per request, we only suport OR logic.
+    $allowed = array_filter(array_map('trim', explode('+', $string)));
+    if (!empty($domain) && in_array($domain->id(), $allowed)) {
+      return AccessResult::allowed()->addCacheContexts(['url.site']);
+    }
+    // If there is no allowed domain, give other access checks a chance.
+    return AccessResult::neutral()->addCacheContexts(['url.site']);
+  }
+
+}

--- a/domain/src/Plugin/views/access/Domain.php
+++ b/domain/src/Plugin/views/access/Domain.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\domain\Plugin\views\access;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\views\Plugin\views\PluginBase;
+use Drupal\domain\DomainLoader;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Access plugin that provides domain-based access control.
+ *
+ * @ViewsAccess(
+ *   id = "domain",
+ *   title = @Translation("Domain"),
+ *   help = @Translation("Access will be granted when accessed from an allowed domain.")
+ * )
+ */
+class Domain extends AccessPluginBase implements CacheableDependencyInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesOptions = TRUE;
+
+  /**
+   * The role storage.
+   *
+   * @var \Drupal\domain\DomainLoader
+   */
+  protected $domainLoader;
+
+  /**
+   * Constructs a Role object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, DomainLoader $domain_loader) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->domainLoader = $domain_loader;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('domain.loader')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(AccountInterface $account) {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRouteDefinition(Route $route) {
+    if ($this->options['domain']) {
+      $route->setRequirement('_domain', (string) implode('+', $this->options['domain']));
+    }
+  }
+
+  public function summaryTitle() {
+    $count = count($this->options['domain']);
+    if ($count < 1) {
+      return $this->t('No domain(s) selected');
+    }
+    elseif ($count > 1) {
+      return $this->t('Multiple domains');
+    }
+    else {
+      $domains = user_role_names();
+      $domain = reset($this->options['domain']);
+      return $domains[$domain];
+    }
+  }
+
+
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['domain'] = array('default' => array());
+
+    return $options;
+  }
+
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    $form['domain'] = array(
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Domain'),
+      '#default_value' => $this->options['domain'],
+      '#options' => array_map('\Drupal\Component\Utility\Html::escape', user_role_names()),
+      '#description' => $this->t('Only the checked domain(s) will be able to access this display.'),
+    );
+  }
+
+  public function validateOptionsForm(&$form, FormStateInterface $form_state) {
+    $domain = $form_state->getValue(array('access_options', 'domain'));
+    $domain = array_filter($domain);
+
+    if (!$domain) {
+      $form_state->setError($form['domain'], $this->t('You must select at least one domain if type is "by domain"'));
+    }
+
+    $form_state->setValue(array('access_options', 'domain'), $domain);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    $dependencies = parent::calculateDependencies();
+
+    foreach (array_keys($this->options['domain']) as $id) {
+      if ($domain = $this->domainStorage->load($id)) {
+        $dependencies[$domain->getConfigDependencyKey()][] = $domain->getConfigDependencyName();
+      }
+    }
+
+    return $dependencies;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return Cache::PERMANENT;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return ['url.site'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return [];
+  }
+
+}

--- a/domain/src/Tests/DomainViewsAccessTest.php
+++ b/domain/src/Tests/DomainViewsAccessTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\domain\Tests;
+
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Tests the domain access plugin for Views.
+ *
+ * @group domain
+ */
+class DomainViewsAccessTest extends DomainTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = array('domain', 'node', 'views');
+
+  /**
+   * Test inactive domain.
+   */
+  public function testInactiveDomain() {
+    // Create five new domains programmatically.
+    $this->domainCreateTestDomains(5);
+    $domains = \Drupal::service('domain.loader')->loadMultiple();
+
+    // Since we cannot read the service request, we place a block
+    // which shows the current domain information.
+    $this->drupalPlaceBlock('views_block__domain_views_access_block_1');
+
+    // The block and page should be visible on example_com and one_example_com.
+    $allowed = ['example_com', 'one_example_com'];
+
+    foreach ($domains as $domain) {
+      $path = $domain->getPath() . 'domain-views-access';
+      $this->DrupalGet($path);
+      if (in_array($domain->id(), $allowed)) {
+        $this->assertResponse('200', 'Access allowed');
+        $this->assertRaw('Test page output.');
+        $this->assertRaw('Test block output.');
+      }
+      else {
+        $this->assertResponse('403', 'Access denied');
+        $this->assertNoRaw('Test page output.');
+        $this->assertNoRaw('Test block output.');
+      }
+    }
+  }
+
+}

--- a/domain/src/Tests/DomainViewsAccessTest.php
+++ b/domain/src/Tests/DomainViewsAccessTest.php
@@ -16,7 +16,7 @@ class DomainViewsAccessTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = array('domain', 'node', 'views');
+  public static $modules = array('domain', 'node', 'views', 'domain_test');
 
   /**
    * Test inactive domain.

--- a/domain/src/Tests/DomainViewsAccessTest.php
+++ b/domain/src/Tests/DomainViewsAccessTest.php
@@ -55,6 +55,14 @@ class DomainViewsAccessTest extends DomainTestBase {
         $this->assertNoRaw('admin');
         $this->assertNoRaw($this->user->getUsername());
       }
+      // Test the block on another page.
+      $this->drupalGet($domain->getPath());
+      if (in_array($domain->id(), $allowed)) {
+        $this->assertRaw($this->user->getUsername());
+      }
+      else {
+        $this->assertNoRaw($this->user->getUsername());
+      }
     }
   }
 

--- a/domain/tests/modules/domain_test/config/optional/views.view.domain_views_access.yml
+++ b/domain/tests/modules/domain_test/config/optional/views.view.domain_views_access.yml
@@ -1,0 +1,213 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - domain.record.example_com
+    - domain.record.one_example_com
+  module:
+    - domain
+    - user
+id: domain_views_access
+label: 'Domain views access'
+module: views
+description: ''
+tag: ''
+base_table: users_field_data
+base_field: uid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: domain
+        options:
+          domain:
+            example_com: example_com
+            one_example_com: one_example_com
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          entity_type: user
+          entity_field: name
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: true
+          table: users_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: user
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+      sorts: {  }
+      title: 'Domain views access'
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'Test page output.'
+            format: basic_html
+          plugin_id: text
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - url.site
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 2
+    display_options:
+      display_extenders: {  }
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      defaults:
+        pager: false
+        header: false
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'Test block output.'
+            format: basic_html
+          plugin_id: text
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.site
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: domain-views-access
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - url.site
+      tags: {  }

--- a/domain/tests/modules/domain_test/config/optional/views.view.domain_views_access.yml
+++ b/domain/tests/modules/domain_test/config/optional/views.view.domain_views_access.yml
@@ -50,23 +50,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: some
         options:
-          items_per_page: 10
+          items_per_page: 1
           offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
       style:
         type: default
       row:
@@ -132,20 +119,7 @@ display:
           group: 1
       sorts: {  }
       title: 'Domain views access'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Test page output.'
-            format: basic_html
-          plugin_id: text
+      header: {  }
       footer: {  }
       empty: {  }
       relationships: {  }
@@ -156,7 +130,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url.query_args
         - url.site
       tags: {  }
   block_1:
@@ -170,24 +143,11 @@ display:
         type: some
         options:
           items_per_page: 5
-          offset: 0
+          offset: 1
       defaults:
         pager: false
         header: false
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Test block output.'
-            format: basic_html
-          plugin_id: text
+      header: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -208,6 +168,5 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url.query_args
         - url.site
       tags: {  }


### PR DESCRIPTION
This still needs a test, which should be pretty simple. Just a basic view in with the test module.

This was a bit tricky because there are multiple types of access checks. We can't just piggyback on the existing DomainAccessCheck, because that's a global and uses different arguments.

Here we introduce a service that only runs access checks on specific routes that require the _domain value.
