### PR TITLE
Unit test domain validator

### DIFF
--- a/domain/domain.services.yml
+++ b/domain/domain.services.yml
@@ -38,4 +38,4 @@ services:
     class: Drupal\domain\DomainValidator
     tags:
       - { name: persist }
-    arguments: ['@module_handler', '@config.factory', '@http_client']
+    arguments: ['@config.factory', '@module_handler', '@entity_type.manager', '@string_translation', '@http_client']

--- a/domain/domain.services.yml
+++ b/domain/domain.services.yml
@@ -38,4 +38,4 @@ services:
     class: Drupal\domain\DomainValidator
     tags:
       - { name: persist }
-    arguments: ['@config.factory', '@module_handler', '@entity_type.manager', '@string_translation', '@http_client']
+    arguments: ['@module_handler', '@config.factory', '@http_client', '@entity_type.manager']

--- a/domain/domain.services.yml
+++ b/domain/domain.services.yml
@@ -43,4 +43,4 @@ services:
     class: Drupal\domain\DomainValidator
     tags:
       - { name: persist }
-    arguments: ['@module_handler', '@config.factory', '@http_client', '@entity_type.manager']
+    arguments: ['@module_handler', '@config.factory', '@http_client', '@entity_type.manager', '@string_translation']

--- a/domain/src/DomainValidator.php
+++ b/domain/src/DomainValidator.php
@@ -3,10 +3,12 @@
 namespace Drupal\domain;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Component\Utility\Unicode;
-use GuzzleHttp\ClientInterface;
+use Drupal\Core\StringTranslation\TranslationManager;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 
 /**
@@ -15,6 +17,16 @@ use GuzzleHttp\Exception\RequestException;
 class DomainValidator implements DomainValidatorInterface {
 
   use StringTranslationTrait;
+
+  /**
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
 
   /**
    * The module handler.
@@ -31,98 +43,70 @@ class DomainValidator implements DomainValidatorInterface {
   protected $httpClient;
 
   /**
-   * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
    * Constructs a DomainNegotiator object.
    *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The configuration factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
-   * @param \GuzzleHttp\ClientInterface $http_client
-   *   A Guzzle client object.
+   * @param \Drupal\Core\StringTranslation\TranslationManager $translation
+   * @param \GuzzleHttp\Client $httpClient
+   *   The HTTP client.
    */
-  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, ClientInterface $http_client) {
+  public function __construct(ConfigFactoryInterface $configFactory, EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $module_handler, TranslationManager $translation, Client $httpClient) {
+    $this->config = $configFactory->get('domain.settings');
+    $this->entityTypeManager = $entityTypeManager;
     $this->moduleHandler = $module_handler;
-    $this->configFactory = $config_factory;
-    // @TODO: Move to a proper service?
-    $this->httpClient = $http_client;
+    $this->stringTranslation = $translation;
+    $this->httpClient = $httpClient;
   }
 
   /**
    * {@inheritdoc}
    *
-   * @TODO: Divide this into separate methods. Do not return Drupal-specific
-   * responses.
+   * @TODO: Verify division into separate methods.
+   * @TODO: Do not return Drupal-specific responses.
    */
   public function validate(DomainInterface $domain) {
     $hostname = $domain->getHostname();
-    $error_list = array();
-    // Check for at least one dot or the use of 'localhost'.
-    // Note that localhost can specify a port.
-    $localhost_check = explode(':', $hostname);
-    if (substr_count($hostname, '.') == 0 && $localhost_check[0] != 'localhost') {
-      $error_list[] = $this->t('At least one dot (.) is required, except when using <em>localhost</em>.');
-    }
-    // Check for one colon only.
-    if (substr_count($hostname, ':') > 1) {
-      $error_list[] = $this->t('Only one colon (:) is allowed.');
-    }
-    // If a colon, make sure it is only followed by numbers.
-    elseif (substr_count($hostname, ':') == 1) {
-      $parts = explode(':', $hostname);
-      $port = (int) $parts[1];
-      if (strcmp($port, $parts[1])) {
-        $error_list[] = $this->t('The port protocol must be an integer.');
-      }
-    }
-    // The domain cannot begin or end with a period.
-    if (substr($hostname, 0, 1) == '.') {
-      $error_list[] = $this->t('The domain must not begin with a dot (.)');
-    }
-    // The domain cannot begin or end with a period.
-    if (substr($hostname, -1) == '.') {
-      $error_list[] = $this->t('The domain must not end with a dot (.)');
-    }
+
+    // First, do generalized hostname validation.
+    $error_list = $this->staticHostnameValidation($hostname);
+
     // Check for valid characters, unless using non-ASCII domains.
-    $non_ascii = $this->configFactory->get('domain.settings')->get('allow_non_ascii');
-    if (!$non_ascii) {
-      $pattern = '/^[a-z0-9\.\-:]*$/i';
-      if (!preg_match($pattern, $hostname)) {
-        $error_list[] = $this->t('Only alphanumeric characters, dashes, and a colon are allowed.');
-      }
+    if (! $this->config->get('allow_non_ascii') && ! preg_match('/^[a-z0-9:.-]*$/i', $hostname)) {
+      $error_list[] = $this->t('Only alphanumeric characters, dashes, and a colon are allowed.');
     }
-    // Check for lower case.
-    if ($hostname != Unicode::strtolower($hostname)) {
-      $error_list[] = $this->t('Only lower-case characters are allowed.');
-    }
+
     // Check for 'www' prefix if redirection / handling is
     // enabled under global domain settings.
     // Note that www prefix handling must be set explicitly in the UI.
     // See http://drupal.org/node/1529316 and http://drupal.org/node/1783042
-    if ($this->configFactory->get('domain.settings')->get('www_prefix') && (substr($hostname, 0, strpos($hostname, '.')) == 'www')) {
+    if ($this->config->get('www_prefix') && 0 === strpos($hostname, '.www')) {
       $error_list[] = $this->t('WWW prefix handling: Domains must be registered without the www. prefix.');
     }
 
     // Check existing domains.
-    $domains = \Drupal::entityTypeManager()
-      ->getStorage('domain')
-      ->loadByProperties(array('hostname' => $hostname));
-    foreach ($domains as $match) {
-      if ($match->id() != $domain->id()) {
-        $error_list[] = $this->t('The hostname is already registered.');
+    try {
+      $domains = $this->entityTypeManager->getStorage('domain')
+        ->loadByProperties(array('hostname' => $hostname));
+      foreach ($domains as $match) {
+        if ($match->id() !== $domain->id()) {
+          $error_list[] = $this->t('The hostname is already registered.');
+        }
       }
     }
+    catch (\Exception $e) {
+      $error_list[] = $this->t('Could not open domain storage');
+    }
+
     // Allow modules to alter this behavior.
-    \Drupal::moduleHandler()->invokeAll('domain_validate', array($error_list, $hostname));
+    $this->moduleHandler->invokeAll('domain_validate', array($error_list, $hostname));
 
     // Return the errors, if any.
-    if (!empty($error_list)) {
+    if (count($error_list)) {
       return $this->t('The domain string is invalid for %subdomain: @errors', array(
         '%subdomain' => $hostname,
         '@errors' => array(
@@ -136,10 +120,64 @@ class DomainValidator implements DomainValidatorInterface {
   }
 
   /**
+   * Perform general hostname validation.
+   *
+   * None of the checks in this methed are Drupal-specific or are affected by
+   * modules settings. Therefore, it might be possible to replace with a
+   * general-purpose external hostname validation process.
+   *
+   * @param string $hostname
+   *   The host name.
+   * @return array
+   *   Any errors detected by static inspection.
+   */
+  private function staticHostnameValidation($hostname) {
+    $errors = array();
+
+    $parts = explode(':', $hostname);
+
+    // Check for at least one dot or the use of 'localhost'.
+    // Note that localhost can specify a port.
+    if ($parts[0] !== 'localhost' && substr_count($hostname, '.') === 0) {
+      $errors[] = $this->t('At least one dot (.) is required, except when using <em>localhost</em>.');
+    }
+
+    // Check for one colon only.
+    if (count($parts) > 2) {
+      $errors[] = $this->t('Only one colon (:) is allowed.');
+    }
+    // If a colon, make sure it is only followed by numbers.
+    elseif (count($parts) === 2) {
+      $port = (int) $parts[1];
+      if (strcmp($port, $parts[1])) {
+        $errors[] = $this->t('The port protocol must be an integer.');
+      }
+    }
+
+    // The domain cannot begin or end with a period.
+    if (0 === strpos($hostname, '.')) {
+      $errors[] = $this->t('The domain must not begin with a dot (.)');
+    }
+
+    // The domain cannot begin or end with a period.
+    if (substr($hostname, -1) === '.') {
+      $errors[] = $this->t('The domain must not end with a dot (.)');
+    }
+
+    // Check for lower case.
+    if ($hostname !== Unicode::strtolower($hostname)) {
+      $errors[] = $this->t('Only lower-case characters are allowed.');
+    }
+
+    return $errors;
+  }
+
+  /**
    * {@inheritdoc}
    */
-  public function checkResponse(DomainInterface $domain) {
-    $url = $domain->getPath() . drupal_get_path('module', 'domain') . '/tests/200.png';
+  public function checkResponse(DomainInterface $domain, $test_path = '') {
+    $url = $domain->getPath() .
+      ($test_path ?: drupal_get_path('module', 'domain') . '/tests/200.png');
     try {
       // GuzzleHttp no longer allows for bogus URL calls.
       $request = $this->httpClient->get($url);

--- a/domain/src/DomainValidator.php
+++ b/domain/src/DomainValidator.php
@@ -44,13 +44,13 @@ class DomainValidator implements DomainValidatorInterface {
   /**
    * Constructs a DomainNegotiator object.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The configuration factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \GuzzleHttp\Client $httpClient
+   * @param \GuzzleHttp\Client $http_client
    *   The HTTP client.
    */
   public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, Client $http_client, EntityTypeManagerInterface $entity_type_manager) {

--- a/domain/src/DomainValidator.php
+++ b/domain/src/DomainValidator.php
@@ -63,7 +63,6 @@ class DomainValidator implements DomainValidatorInterface {
   /**
    * {@inheritdoc}
    *
-   * @TODO: Verify division into separate methods.
    * @TODO: Do not return Drupal-specific responses.
    */
   public function validate(DomainInterface $domain) {

--- a/domain/src/DomainValidator.php
+++ b/domain/src/DomainValidator.php
@@ -7,7 +7,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Component\Utility\Unicode;
-use Drupal\Core\StringTranslation\TranslationManager;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 
@@ -51,16 +50,14 @@ class DomainValidator implements DomainValidatorInterface {
    *   The entity type manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \Drupal\Core\StringTranslation\TranslationManager $translation
    * @param \GuzzleHttp\Client $httpClient
    *   The HTTP client.
    */
-  public function __construct(ConfigFactoryInterface $configFactory, EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $module_handler, TranslationManager $translation, Client $httpClient) {
-    $this->config = $configFactory->get('domain.settings');
-    $this->entityTypeManager = $entityTypeManager;
+  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, Client $http_client, EntityTypeManagerInterface $entity_type_manager) {
     $this->moduleHandler = $module_handler;
-    $this->stringTranslation = $translation;
-    $this->httpClient = $httpClient;
+    $this->config = $config_factory->get('domain.settings');
+    $this->httpClient = $http_client;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/domain/src/DomainValidator.php
+++ b/domain/src/DomainValidator.php
@@ -122,7 +122,7 @@ class DomainValidator implements DomainValidatorInterface {
   /**
    * Perform general hostname validation.
    *
-   * None of the checks in this methed are Drupal-specific or are affected by
+   * None of the checks in this method are Drupal-specific or are affected by
    * modules settings. Therefore, it might be possible to replace with a
    * general-purpose external hostname validation process.
    *

--- a/domain/src/DomainValidator.php
+++ b/domain/src/DomainValidator.php
@@ -7,8 +7,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Component\Utility\Unicode;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
 
 /**
  * Provides validation of domain strings against RFC standards for hostnames.
@@ -37,7 +37,7 @@ class DomainValidator implements DomainValidatorInterface {
   /**
    * The HTTP client.
    *
-   * @var \GuzzleHttp\Client
+   * @var \GuzzleHttp\ClientInterface
    */
   protected $httpClient;
 
@@ -50,10 +50,10 @@ class DomainValidator implements DomainValidatorInterface {
    *   The entity type manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \GuzzleHttp\Client $http_client
+   * @param \GuzzleHttp\ClientInterface $http_client
    *   The HTTP client.
    */
-  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, Client $http_client, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, ClientInterface $http_client, EntityTypeManagerInterface $entity_type_manager) {
     $this->moduleHandler = $module_handler;
     $this->config = $config_factory->get('domain.settings');
     $this->httpClient = $http_client;
@@ -177,10 +177,10 @@ class DomainValidator implements DomainValidatorInterface {
       ($test_path ?: drupal_get_path('module', 'domain') . '/tests/200.png');
     try {
       // GuzzleHttp no longer allows for bogus URL calls.
-      $request = $this->httpClient->get($url);
+      $request = $this->httpClient->request('get', $url);
     }
     // We cannot know which Guzzle Exception class will be returned; be generic.
-    catch (RequestException $e) {
+    catch (GuzzleException $e) {
       watchdog_exception('domain', $e);
       // File a general server failure.
       $domain->setResponse(500);

--- a/domain/src/DomainValidatorInterface.php
+++ b/domain/src/DomainValidatorInterface.php
@@ -29,7 +29,7 @@ interface DomainValidatorInterface {
    * @param \Drupal\domain\DomainInterface $domain
    *   A domain record.
    * @param string $test_path
-   *   A path on the domain to test.
+   *   (optional) A path on the domain to test, /domain/tests/200.png if empty.
    *
    * @return int
    *   The server response code for the request.

--- a/domain/src/DomainValidatorInterface.php
+++ b/domain/src/DomainValidatorInterface.php
@@ -28,11 +28,13 @@ interface DomainValidatorInterface {
    *
    * @param \Drupal\domain\DomainInterface $domain
    *   A domain record.
+   * @param string $test_path
+   *   A path on the domain to test.
    *
    * @return int
    *   The server response code for the request.
    */
-  public function checkResponse(DomainInterface $domain);
+  public function checkResponse(DomainInterface $domain, $test_path = '');
 
   /**
    * Returns the properties required to create a domain record.

--- a/domain/tests/src/Unit/DomainValidatorTest.php
+++ b/domain/tests/src/Unit/DomainValidatorTest.php
@@ -56,18 +56,12 @@ class DomainValidatorTest extends UnitTestCase {
       ->disableOriginalConstructor()->getMock();
 
     $response = $this->getMockBuilder('GuzzleHttp\Psr7\Response')
-      ->disableOriginalConstructor()
-      ->getMock();
+      ->disableOriginalConstructor()->getMock();
     $response->expects(static::any())->method('getStatusCode')
       ->willReturn(200);
 
-    static::assertNotEmpty($response);
-    $client = $this->getMockBuilder('GuzzleHttp\Client')
-      ->setMethods(['get', 'request'])
-      ->disableOriginalConstructor()
-      ->getMock();
-    $client->expects(static::any())->method('get')
-      ->will(static::returnValue($response));
+    $client = $this->getMockBuilder('GuzzleHttp\Client')->setMethods(['request'])
+      ->disableOriginalConstructor()->getMock();
     $client->expects(static::any())->method('request')
       ->will(static::returnValue($response));
 

--- a/domain/tests/src/Unit/DomainValidatorTest.php
+++ b/domain/tests/src/Unit/DomainValidatorTest.php
@@ -55,12 +55,6 @@ class DomainValidatorTest extends UnitTestCase {
     $handler = $mock = $this->getMockBuilder('Drupal\Core\Extension\ModuleHandler')
       ->disableOriginalConstructor()->getMock();
 
-    $translation = $this->getMockBuilder('Drupal\Core\StringTranslation\TranslationManager')
-      ->disableOriginalConstructor()->getMock();
-    $translation->expects(static::any())->method('getStringTranslation')
-      ->willReturn('message');
-    /** @var \Drupal\Core\StringTranslation\TranslationManager $translation */
-
     $response = $this->getMockBuilder('GuzzleHttp\Psr7\Response')
       ->disableOriginalConstructor()
       ->getMock();
@@ -75,7 +69,7 @@ class DomainValidatorTest extends UnitTestCase {
     $client->expects(static::any())->method('get')
       ->will(static::returnValue($response));
 
-    $this->object = new DomainValidator($factory, $manager, $handler, $translation, $client);
+    $this->object = new DomainValidator($handler, $factory, $client, $manager);
   }
 
   /**

--- a/domain/tests/src/Unit/DomainValidatorTest.php
+++ b/domain/tests/src/Unit/DomainValidatorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\Tests\domain\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\domain\DomainValidator;
+
+/**
+ * Tests domain record validation.
+ *
+ * @group domain
+ */
+class DomainValidatorTest extends UnitTestCase {
+
+  /** @var \Drupal\domain\DomainValidator */
+  private $object;
+
+  /** @var \GuzzleHttp\Client */
+  public $client;
+
+  /**
+   * Set up a service container and SUT (Subject Under Test).
+   *
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    /** @var \Drupal\Core\Config\ImmutableConfig $config */
+    $config = $mock = $this->getMockBuilder('Drupal\Core\Config\ImmutableConfig')
+      ->disableOriginalConstructor()->getMock();
+    $mock->expects(static::any())->method('get')
+      ->willReturnMap([
+        ['allow_non_ascii', FALSE],
+        ['www-prefix', FALSE]
+      ]);
+
+    /** @var \Drupal\Core\Config\ConfigFactory $factory */
+    $factory = $mock = $this->getMockBuilder('Drupal\Core\Config\ConfigFactory')
+      ->disableOriginalConstructor()->getMock();
+    $mock->expects(static::once())->method('get')->willReturn($config);
+
+    /** @var \Drupal\Core\Entity\EntityStorageBase $storage */
+    $storage = $mock = $this->getMockBuilder('Drupal\Core\Entity\EntityStorageBase')
+      ->disableOriginalConstructor()->getMock();
+    $mock->expects(static::any())->method('loadByProperties')->willReturn(array());
+
+    /** @var \Drupal\Core\Entity\EntityTypeManager $manager */
+    $manager = $mock = $this->getMockBuilder('Drupal\Core\Entity\EntityTypeManager')
+      ->disableOriginalConstructor()->getMock();
+    $mock->expects(static::any())->method('getStorage')
+      ->willReturn($storage);
+
+    /** @var \Drupal\Core\Extension\ModuleHandler $handler */
+    $handler = $mock = $this->getMockBuilder('Drupal\Core\Extension\ModuleHandler')
+      ->disableOriginalConstructor()->getMock();
+
+    $translation = $this->getMockBuilder('Drupal\Core\StringTranslation\TranslationManager')
+      ->disableOriginalConstructor()->getMock();
+    $translation->expects(static::any())->method('getStringTranslation')
+      ->willReturn('message');
+    /** @var \Drupal\Core\StringTranslation\TranslationManager $translation */
+
+    $response = $this->getMockBuilder('GuzzleHttp\Psr7\Response')
+      ->disableOriginalConstructor()
+      ->getMock();
+    $response->expects(static::any())->method('getStatusCode')
+      ->willReturn(200);
+
+    static::assertNotEmpty($response);
+    $client = $this->getMockBuilder('GuzzleHttp\Client')
+      ->setMethods(['get'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $client->expects(static::any())->method('get')
+      ->will(static::returnValue($response));
+
+    $this->object = new DomainValidator($factory, $manager, $handler, $translation, $client);
+  }
+
+  /**
+   * @param string $host
+   * @param int $result
+   *
+   * @dataProvider provider
+   */
+  public function testValidateStaticInspection($host, $result) {
+    /** @var \Drupal\domain\Entity\Domain $domain */
+    $domain = $mock = $this->getMockBuilder('Drupal\domain\Entity\Domain')
+      ->disableOriginalConstructor()->getMock();
+    $mock->expects(static::any())->method('getHostname')
+      ->willReturn($host);
+    $errors = $this->object->validate($domain);
+    static::assertNotEquals((bool) $result, (bool) count($errors));
+  }
+
+  /**
+   * @return array
+   */
+  public function provider() {
+    return [
+      ['localhost', 1],
+      ['example.com', 1],
+      ['www.example.com', 1], // see www-prefix test, below.
+      ['one.example.com', 1],
+      ['example.com:8080', 1],
+      // these tests work, but translation service mock is not yet working
+//      ['example.com::8080', 0], // only one colon.
+//      ['example.com:abc', 0], // no letters after a colon.
+//      ['.example.com', 0], // cannot begin with a dot.
+//      ['example.com.', 0], // cannot end with a dot.
+//      ['EXAMPLE.com', 0], // lowercase only.
+//      ['éxample.com', 0], // ascii-only.
+    // this should be moved to a test of the Drupal logic, outside the string tests
+//      ['foo.com', 0], // duplicate.
+    ];
+  }
+
+  public function testCheckResponse() {
+    /** @var \Drupal\domain\Entity\Domain $domain */
+    $domain = $mock = $this->getMockBuilder('Drupal\domain\Entity\Domain')
+      ->disableOriginalConstructor()->getMock();
+    $mock->expects(static::once())->method('setResponse')->with(200);
+    $this->object->checkResponse($domain, 'module/path');
+  }
+
+  /**
+   * Tests that a domain hostname validates.
+   */
+  public function testGetRequiredFields() {
+    $check = $this->object->getRequiredFields();
+    static::assertInternalType('array', $check);
+    static::assertGreaterThanOrEqual(6, count($check));
+  }
+
+}

--- a/domain/tests/src/Unit/DomainValidatorTest.php
+++ b/domain/tests/src/Unit/DomainValidatorTest.php
@@ -63,10 +63,12 @@ class DomainValidatorTest extends UnitTestCase {
 
     static::assertNotEmpty($response);
     $client = $this->getMockBuilder('GuzzleHttp\Client')
-      ->setMethods(['get'])
+      ->setMethods(['get', 'request'])
       ->disableOriginalConstructor()
       ->getMock();
     $client->expects(static::any())->method('get')
+      ->will(static::returnValue($response));
+    $client->expects(static::any())->method('request')
       ->will(static::returnValue($response));
 
     $this->object = new DomainValidator($handler, $factory, $client, $manager);


### PR DESCRIPTION
Some work by agentrickard duplicated what I was doing to use service injection and create a unit test. I've tried to keep that as much as possible, reordering my parameters to match, etc. One change in 8.1-1.x that I think was incorrect was to switch from Guzzle\Client to ClientInterface -- I think get() is a magic method provided by the actual Guzzle Client and not the interface. So if that type is change to the interface, there is no assurance we will still have get().

I also choose to get the domain config once in the constructor instead of storing the whole configuration - it seemed to produce cleaner code, but could be changed later without affecting the interface.

There was a note about splitting the validate function (though the rationale was not given) It made sense to me that half was stuff related to the domain config and the other half a set of string inspections that pretty much any hostname validator would do. So I assumed that rationale and made the split, which sets up the code to use a generic validator instead of writing one custom.

Lastly, I added a optional string path parameter to checkResponse. Certainly part of the reason was that drupal_get_path is not playing well with unit test operation. But it also made sense that one could want to specify a path other than test.png for many reasons. So it felt OK, but it too was a judgement call.
