### PR TITLE
Resolve places where subclasses mask parts of parent class

### DIFF
--- a/domain/src/Controller/DomainControllerBase.php
+++ b/domain/src/Controller/DomainControllerBase.php
@@ -26,33 +26,26 @@ class DomainControllerBase extends ControllerBase {
   protected $entityStorage;
 
   /**
-   * The entity manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityManager;
-
-  /**
    * Constructs a new DomainControllerBase.
    *
    * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
    *   The storage controller.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity manager.
    */
-  public function __construct(EntityStorageInterface $entity_storage, EntityTypeManagerInterface $entity_manager) {
+  public function __construct(EntityStorageInterface $entity_storage, EntityTypeManagerInterface $entity_type_manager) {
     $this->entityStorage = $entity_storage;
-    $this->entityManager = $entity_manager;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    $entity_manager = $container->get('entity_type.manager');
+    $entity_type_manager = $container->get('entity_type.manager');
     return new static(
-      $entity_manager->getStorage('domain'),
-      $entity_manager
+      $entity_type_manager->getStorage('domain'),
+      $entity_type_manager
     );
   }
 

--- a/domain/src/DomainListBuilder.php
+++ b/domain/src/DomainListBuilder.php
@@ -3,8 +3,6 @@
 namespace Drupal\domain;
 
 use Drupal\Core\Config\Entity\DraggableListBuilder;
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -15,14 +13,9 @@ use Drupal\Core\Url;
 class DomainListBuilder extends DraggableListBuilder {
 
   /**
-   * Provide class-specific value of $entitiesKey.
-   *
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage) {
-    $this->entitiesKey = 'domains';
-    parent::__construct($entity_type, $storage);
-  }
+  protected $entitiesKey = 'domains';
 
   /**
    * {@inheritdoc}

--- a/domain/src/DomainListBuilder.php
+++ b/domain/src/DomainListBuilder.php
@@ -13,9 +13,14 @@ use Drupal\Core\Url;
 class DomainListBuilder extends DraggableListBuilder {
 
   /**
+   * Provide class-specific value of $entitiesKey.
+   *
    * {@inheritdoc}
    */
-  protected $entitiesKey = 'domains';
+  public function __construct(\Drupal\Core\Entity\EntityTypeInterface $entity_type, \Drupal\Core\Entity\EntityStorageInterface $storage) {
+    parent::__construct($entity_type, $storage);
+    $this->entitiesKey = 'domains';
+  }
 
   /**
    * {@inheritdoc}

--- a/domain/src/DomainListBuilder.php
+++ b/domain/src/DomainListBuilder.php
@@ -3,6 +3,8 @@
 namespace Drupal\domain;
 
 use Drupal\Core\Config\Entity\DraggableListBuilder;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -17,9 +19,9 @@ class DomainListBuilder extends DraggableListBuilder {
    *
    * {@inheritdoc}
    */
-  public function __construct(\Drupal\Core\Entity\EntityTypeInterface $entity_type, \Drupal\Core\Entity\EntityStorageInterface $storage) {
-    parent::__construct($entity_type, $storage);
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage) {
     $this->entitiesKey = 'domains';
+    parent::__construct($entity_type, $storage);
   }
 
   /**

--- a/domain/src/Entity/Domain.php
+++ b/domain/src/Entity/Domain.php
@@ -74,13 +74,6 @@ class Domain extends ConfigEntityBase implements DomainInterface {
   protected $domain_id;
 
   /**
-   * The domain record UUID.
-   *
-   * @var string
-   */
-  protected $uuid;
-
-  /**
    * The domain list name (e.g. Drupal).
    *
    * @var string
@@ -93,13 +86,6 @@ class Domain extends ConfigEntityBase implements DomainInterface {
    * @var string
    */
   protected $hostname;
-
-  /**
-   * The domain status.
-   *
-   * @var boolean
-   */
-  protected $status;
 
   /**
    * The domain record sort order.

--- a/domain_alias/src/Entity/DomainAlias.php
+++ b/domain_alias/src/Entity/DomainAlias.php
@@ -60,13 +60,6 @@ class DomainAlias extends ConfigEntityBase implements DomainAliasInterface {
   protected $domain_id;
 
   /**
-   * The domain alias record UUID.
-   *
-   * @var string
-   */
-  protected $uuid;
-
-  /**
    * The domain alias record pattern.
    *
    * @var string

--- a/domain_config/src/DomainConfigServiceProvider.php
+++ b/domain_config/src/DomainConfigServiceProvider.php
@@ -15,7 +15,7 @@ use Drupal\domain_config\Routing\DomainRouteProvider;
  *
  * @see https://www.drupal.org/node/2662196#comment-10838164
  */
-class DomainConfigServiceProvider extends ServiceProviderBase implements ServiceModifierInterface {
+class DomainConfigServiceProvider extends ServiceProviderBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Most of these seem to be innocent in that the subclass does not actually use the property it masked. So the accessors on the parent class would access the original properties and the behavior so far was probably no different than what you would expect. So they are about protecting from future undocumented surprises.

It's worth calling out DomainControllerBase, however. In that class, the EntityTypeManager was being written into a local version of the EntityManager. Both are properties in the parent class. I looked at the code and I think that because DomainAliasController uses \Drupal::entityTypeManager(), that error I think had no consequences either. But I think we would have started seeing errors if we had been using dependency injection for the EntityTypeManager service. It's worth someone else looking at the code to see if you agree with my analysis.
