### PR TITLE
Domain config overrides in settings.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,17 @@ addons:
 
 cache:
   directories:
-    - $HOME/.composer/cache/files
+    - $HOME/.composer/cache
 
 env:
-  - DRUPAL=8.1.x
-  - DRUPAL=8.2.x
+  global:
+    # add composer's global bin directory to the path
+    # see: https://github.com/drush-ops/drush#install---composer
+    - PATH="$PATH:$HOME/.composer/vendor/bin"
+
+  matrix:
+    - DRUPAL=8.2.x
+    - DRUPAL=8.3.x
 
 mysql:
   database: domain
@@ -32,24 +38,23 @@ notifications:
   email: false
 
 before_install:
-  # Add composer's global bin directory to the path
-  # see: https://github.com/drush-ops/drush#install---composer
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
-
   # Remove Xdebug. Not an issue for PHP 7.
   - phpenv config-rm xdebug.ini || true
 
   - composer self-update
 
-install:
   # Install Drush.
-  - composer global require drush/drush:8.*
-  - phpenv rehash
+  - composer global require --no-interaction drush/drush:8.*
 
-before_script:
+install:
+  # Optimize MySQL timeout and max packet size.
+  - echo "mysql.connect_timeout=3000" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "default_socket_timeout=3000" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - mysql -e 'create database domain'
   - mysql -e "SET GLOBAL wait_timeout = 36000;"
   - mysql -e "SET GLOBAL max_allowed_packet = 134209536;"
+
+before_script:
 
   # Remember the current rules test directory for later use in the Drupal installation.
   - TESTDIR=$(pwd)

--- a/domain/src/Tests/DomainGetResponseTest.php
+++ b/domain/src/Tests/DomainGetResponseTest.php
@@ -7,14 +7,9 @@ use Drupal\Component\Render\FormattableMarkup;
 /**
  * Tests domain record HTTP response.
  *
- * Note: Class is called DomainIResponseTest on purpose as for some
- * unexplained reason when it is DomainResponseTest and runs after
- * DomainNegotiatorTest, it plain fails due to timeout (no matter how high it
- * gets set in DomainValidator::checkResponse().
- *
  * @group domain
  */
-class DomainIResponseTest extends DomainTestBase {
+class DomainGetResponseTest extends DomainTestBase {
 
   /**
    * Tests that a domain response is proper.

--- a/domain/src/Tests/DomainIResponseTest.php
+++ b/domain/src/Tests/DomainIResponseTest.php
@@ -1,14 +1,20 @@
 <?php
 
 namespace Drupal\domain\Tests;
+
 use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Tests domain record HTTP response.
  *
+ * Note: Class is called DomainIResponseTest on purpose as for some
+ * unexplained reason when it is DomainResponseTest and runs after
+ * DomainNegotiatorTest, it plain fails due to timeout (no matter how high it
+ * gets set in DomainValidator::checkResponse().
+ *
  * @group domain
  */
-class DomainResponseTest extends DomainTestBase {
+class DomainIResponseTest extends DomainTestBase {
 
   /**
    * Tests that a domain response is proper.

--- a/domain/src/Tests/DomainTokenTest.php
+++ b/domain/src/Tests/DomainTokenTest.php
@@ -48,7 +48,7 @@ class DomainTokenTest extends DomainTestBase {
         // context.
         $value = $domain->{$callback}();
         if ($token == '[domain:url]') {
-          $value = str_replace('user', '', $value);
+          $value = str_replace('user', '/', $value);
         }
         $this->assertRaw('<td>' . $value . '</td>', 'Value set correctly to ' . $value);
       }

--- a/domain_config/README.md
+++ b/domain_config/README.md
@@ -80,6 +80,18 @@ Note that, unlike when you exported the item, here you always select "Simple
 configuration" as the configuration type to import, independent of the type of
 configuration you're overriding.
 
+settings.php overrides
+----------------------
+
+For environment-specific or sensitive overrides, use the settings.php method.
+In the above case, add
+`$conf['domain.config.three_example_com.en.system.site']['name'] = "My special site";`
+to your local settings.php file. This will ensure that the `three.example.com`
+domain gets the correct value regardless of other module overrides.
+
+Read more about the "Configuration override system"
+at https://www.drupal.org/node/1928898.
+
 Installation
 ============
 

--- a/domain_config/src/DomainConfigOverrider.php
+++ b/domain_config/src/DomainConfigOverrider.php
@@ -94,6 +94,14 @@ class DomainConfigOverrider implements ConfigFactoryOverrideInterface {
         elseif ($override = $this->storage->read($config_name['domain'])) {
           $overrides[$name] = $override;
         }
+
+        // Apply any settings.php overrides.
+        if (isset($GLOBALS['config'][$config_name['langcode']])) {
+          $overrides[$name] = $GLOBALS['config'][$config_name['langcode']];
+        }
+        elseif (isset($GLOBALS['config'][$config_name['domain']])) {
+          $overrides[$name] = $GLOBALS['config'][$config_name['domain']];
+        }
       }
     }
     return $overrides;

--- a/domain_config/src/Tests/DomainConfigOverriderTest.php
+++ b/domain_config/src/Tests/DomainConfigOverriderTest.php
@@ -54,6 +54,34 @@ class DomainConfigOverriderTest extends DomainConfigTestBase {
   }
 
   /**
+   * Tests that domain-specific variable overrides in settings.php works.
+   */
+  public function testDomainConfigOverriderFromSettings() {
+    // Set up overrides.
+    $settings = [];
+    $settings['config']['domain.config.one_example_com.en.system.site']['name'] = (object) [
+      'value' => 'First',
+      'required' => TRUE,
+    ];
+    $settings['config']['domain.config.four_example_com.system.site']['name'] = (object) [
+      'value' => 'Four overridden in settings',
+      'required' => TRUE,
+    ];
+    $this->writeSettings($settings);
+
+    // Create four new domains programmatically.
+    $this->domainCreateTestDomains(5);
+    $domains = \Drupal::service('domain.loader')->loadMultiple(['one_example_com', 'four_example_com']);
+
+    $domain_one = $domains['one_example_com'];
+    $this->drupalGet($domain_one->getPath() . 'user/login');
+    $this->assertRaw('<title>Log in | First</title>', 'Found overridden slogan for one.example.com.');
+
+    $domain_four = $domains['four_example_com'];
+    $this->drupalGet($domain_four->getPath() . 'user/login');
+    $this->assertRaw('<title>Log in | Four overridden in settings</title>', 'Found overridden slogan for four.example.com.');
+  }
+  /**
    * Returns the expected site name value from our test configuration.
    *
    * @param DomainInterface $domain


### PR DESCRIPTION
Based on #284.

This PR enables `DomainConfigOverrider` to pick up configuration changes in settings.php

Somehow it feels more natural to have `$config['domain.config'][$domain_id][$langcode][$config_name];` or `$config['domain.config'][$domain_id][$config_name];`, but for now, `$config["domain.config.{$domain_id}.{$langcode}.{$config_name}"];` will have to do

ToDo:
- [x] tests