### PR TITLE
Alpha update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ Changelog
 =====
 
 31-JUL-2016 8.x-1.0-alpha1
+22-AUG-2016 8.x-1.0-alpha2
+30-AUG-2016 8.x-1.0-alpha3
+01-SEP-2016 8.x-1.0-alpha4
+25-OCT-2016 8.x-1.0-alpha5
+20-NOV-2016 8.x-1.0-alpha6
+
+06-DEC-2016 Adds the domain_alpha module to handle critical pre-release updates.
 
 Status
 ====

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Operations are not yet supported.
 
 For a complete feature status list, see [CHANGELOG.md](https://github.com/agentrickard/domain/blob/8.x-1.x/CHANGELOG.md)
 
+Alpha release updates
+------
+
+A limited set of updates are provided for major architecture changes during the
+alpha release.
+
+You can run these updates by enabling the `domain_alpha` module and running
+Drupal's database updates.
+
+
 Implementation Notes
 ======
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ alpha release.
 You can run these updates by enabling the `domain_alpha` module and running
 Drupal's database updates. The updates and affected versions are:
 
-* Update 8001: Affects versions of Alpha6 or lower. Does not affect installs
-made after 06-DEC-2016.
-
+* Update 8001: Affects versions of Alpha6 or lower.
 
 Implementation Notes
 ======

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ A limited set of updates are provided for major architecture changes during the
 alpha release.
 
 You can run these updates by enabling the `domain_alpha` module and running
-Drupal's database updates.
+Drupal's database updates. The updates and affected versions are:
+
+* Update 8001: Affects versions of Alpha6 or lower. Does not affect installs
+made after 06-DEC-2016.
 
 
 Implementation Notes

--- a/domain/src/Entity/Domain.php
+++ b/domain/src/Entity/Domain.php
@@ -370,7 +370,7 @@ class Domain extends ConfigEntityBase implements DomainInterface {
     // across environments. Instead, we use the crc32 hash function to create a
     // unique numeric id for each domain. In some systems (Windows?) we have
     // reports of crc32 returning a negative number. Issue #2794047.
-    $this->domain_id = abs((int) crc32($this->getHostname()));
+    $this->domain_id = abs((int) crc32($this->id()));
   }
 
   /**

--- a/domain_alpha/domain_alpha.info.yml
+++ b/domain_alpha/domain_alpha.info.yml
@@ -1,0 +1,8 @@
+name: Domain Alpha Updates
+description: 'Provides per-release updates for critical changes.'
+type: module
+package: Domain
+version: VERSION
+core: 8.x
+dependencies:
+  - domain

--- a/domain_alpha/domain_alpha.install
+++ b/domain_alpha/domain_alpha.install
@@ -8,14 +8,23 @@
 /**
  * Update domain id to new value.
  */
-function domain_alpha_update_8000(&$sandbox) {
+function domain_alpha_update_8001(&$sandbox) {
   // Load all domains and update the id.
+  $rebuld = FALSE;
   $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
   foreach ($domains as $domain) {
+    // Check to see if this update is needed.
     /** @var $domain \Drupal\domain\Entity\Domain */
+    $id = $domain->getDomainId();
     $domain->createDomainId();
-    $domain->save();
+    $new_id = $domain->getDomainId();
+    if ($id != $new_id) {
+      $domain->save();
+      $rebuild = TRUE;
+    }
   }
-  // Trigger permissions rebuild action.
-  node_access_needs_rebuild(TRUE);
+  if ($rebuild) {
+    // Trigger permissions rebuild action.
+    node_access_needs_rebuild(TRUE);
+  }
 }

--- a/domain_alpha/domain_alpha.install
+++ b/domain_alpha/domain_alpha.install
@@ -9,15 +9,18 @@
  * Update domain id to new value.
  */
 function domain_alpha_update_8001(&$sandbox) {
-  // Load all domains and update the id.
-  $rebuld = FALSE;
+  // Set the node_access rebuild flag. Only update if an id changes.
+  $rebuild = FALSE;
+  // Load all domains and update the id, if necessary.
   $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
   foreach ($domains as $domain) {
-    // Check to see if this update is needed.
     /** @var $domain \Drupal\domain\Entity\Domain */
+    // Existing id.
     $id = $domain->getDomainId();
+    // New id.
     $domain->createDomainId();
     $new_id = $domain->getDomainId();
+    // Check to see if this update is needed.
     if ($id != $new_id) {
       $domain->save();
       $rebuild = TRUE;

--- a/domain_alpha/domain_alpha.install
+++ b/domain_alpha/domain_alpha.install
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Pre-release updates hooks for Domain modules.
+ */
+
+/**
+ * Update domain id to new value.
+ */
+function domain_alpha_update_8000(&$sandbox) {
+  // Load all domains and update the id.
+  $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
+  foreach ($domains as $domain) {
+    /** @var $domain \Drupal\domain\Entity\Domain */
+    $domain->createDomainId();
+    $domain->save();
+  }
+  // Trigger permissions rebuild action.
+  node_access_needs_rebuild(TRUE);
+}

--- a/domain_alpha/domain_alpha.install
+++ b/domain_alpha/domain_alpha.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Pre-release updates hooks for Domain modules.
+ * Pre-release update hooks for Domain modules.
  */
 
 /**


### PR DESCRIPTION
Takes the work in #296 and #298 and provides a reliable upgrade path.

I think this is worth doing, even though we don't support all alpha changes (especially permissions.) This code changes underlying data structures and poses a security issue, so providing a means to run the update seems responsible.