### PR TITLE
Fixing saving of domain settings when config has not yet been created

### DIFF
--- a/domain/src/Form/DomainSettingsForm.php
+++ b/domain/src/Form/DomainSettingsForm.php
@@ -69,11 +69,11 @@ class DomainSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('domain.settings');
     foreach ($this->settingsKeys() as $key) {
-      $this->config('domain.settings')
-        ->set($key, $form_state->getValue($key));
+      $config->set($key, $form_state->getValue($key));
     }
-    $this->config('domain.settings')->save();
+    $config->save();
     parent::submitForm($form, $form_state);
   }
 


### PR DESCRIPTION
I noticed that domain settings cannot be saved if the configuration has not yet been created.

This is because a `$this->config()` returns a new config object on each iteration of the foreach loop in the submit handler.

To reproduce the issue, remove domain.settings.yml from the sync directory and re-import config. The settings can no longer be saved through the form.

I've updated the code to get the config object once, then reuse in the foreach loop. 