### PR TITLE
303 entity browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Changelog
 01-SEP-2016 8.x-1.0-alpha4
 25-OCT-2016 8.x-1.0-alpha5
 20-NOV-2016 8.x-1.0-alpha6
-
 06-DEC-2016 Adds the domain_alpha module to handle critical pre-release updates.
+13-DEC-2016 8.x-1.0-alpha7
 
 Status
 ====

--- a/domain/src/DomainElementManager.php
+++ b/domain/src/DomainElementManager.php
@@ -40,6 +40,11 @@ class DomainElementManager implements DomainElementManagerInterface {
    * @inheritdoc
    */
   public function setFormOptions(array $form, FormStateInterface $form_state, $field_name, $hide_on_disallow = FALSE) {
+    // There are cases, such as Entity Browser, where the form is partially
+    // invoked, but without our fields.
+    if (!isset($form[$field_name])) {
+      return $form;
+    }
     $fields = $this->fieldList($field_name);
     $disallowed = $this->disallowedOptions($form_state, $form[$field_name]);
     if (!empty($disallowed)) {


### PR DESCRIPTION
In the context of using Entity Broswer, an AJAX load of the node form causes a fatal error in the ElementManager.