### PR TITLE
#305: fix variable name error.

### DIFF
--- a/domain/domain.module
+++ b/domain/domain.module
@@ -142,9 +142,9 @@ function domain_confirm_fields($entity_type, $bundle, $text = array()) {
         'module' => 'entity_reference',
         'settings' => ['target_type' => 'domain'],
       ];
-      $field_storage = FieldStorageConfig::create($new_field_storage);
+      $field_storage_config = FieldStorageConfig::create($field_storage);
 
-      $field_storage->save();
+      $field_storage_config->save();
     }
 
     $id = $storage_id = $entity_type . '.' . $bundle . '.' . DOMAIN_ADMIN_FIELD;


### PR DESCRIPTION
Fixes #305. Currently the `$new_field_storage` variable in `domain_confirm_fields()` is undeclared. Change it to the variable that's declared. Also change `$field_storage` to `$field_storage_config` for parallelism with following block of code, which uses `$field_config`.