### PR TITLE
Dependencies are wrong https://www.drupal.org/node/2848014

### DIFF
--- a/domain/domain.install
+++ b/domain/domain.install
@@ -33,7 +33,7 @@ function domain_uninstall() {
   $field_storage_config = \Drupal::entityTypeManager()
     ->getStorage('field_storage_config');
 
-  $id = $type . '.' . DOMAIN_ADMIN_FIELD;
+  $id = 'user.' . DOMAIN_ADMIN_FIELD;
   if ($field = $field_storage_config->load($id)) {
     $field->delete();
   }

--- a/domain/domain.module
+++ b/domain/domain.module
@@ -138,7 +138,6 @@ function domain_confirm_fields($entity_type, $bundle, $handler = 'default:domain
         'id' => $storage_id,
         'field_name' => DOMAIN_ADMIN_FIELD,
         'type' => 'entity_reference',
-        'dependencies' => 'domain' , 'user',
         'entity_type' => 'user',
         'cardinality' => -1,
         'module' => 'entity_reference',


### PR DESCRIPTION
Issue #2848014 by marcelovani, andypost: Invalid dependency array on update hook for field storage of user.field_domain_admin

Entity reference fields provides proper permissions by default