### PR TITLE
Make module work with config sync

### DIFF
--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -475,7 +475,11 @@ function domain_access_entity_field_access($operation, FieldDefinitionInterface 
  * Creates our fields when new node types are created.
  */
 function domain_access_node_type_insert(EntityInterface $entity) {
-  domain_access_confirm_fields('node', $entity->id());
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityInterface $entity */
+  if (!$entity->isSyncing()) {
+    // Do not fire hook when config sync in progress.
+    domain_access_confirm_fields('node', $entity->id());
+  }
 }
 
 /**
@@ -603,6 +607,11 @@ function domain_access_views_data_alter(array &$data) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function domain_access_domain_insert($entity) {
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityInterface $entity */
+  if ($entity->isSyncing()) {
+    // Do not fire hook when config sync in progress.
+    return;
+  }
   $id = 'domain_access_add_action.' . $entity->id();
   $controller = \Drupal::entityTypeManager()->getStorage('action');
   if (!$controller->load($id)) {

--- a/domain_source/domain_source.module
+++ b/domain_source/domain_source.module
@@ -66,7 +66,11 @@ function domain_source_confirm_fields($entity_type, $bundle) {
  * @TODO: Make this possible for all entity types.
  */
 function domain_source_node_type_insert(EntityInterface $entity) {
-  domain_source_confirm_fields('node', $entity->id());
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityInterface $entity */
+  if (!$entity->isSyncing()) {
+    // Do not fire hook when config sync in progress.
+    domain_source_confirm_fields('node', $entity->id());
+  }
 }
 
 /**


### PR DESCRIPTION
When using config synchronization all config files are already shipped, but hook are fire and cause errors

```
Deleted and replaced configuration entity                                [error]
"field.field.node.article.field_domain_source"
Unexpected error during import with operation create for                 [error]
field.field.node.article.field_domain_source: Attempt to create a
field field_domain_source that does not exist on entity type node.
Deleted and replaced configuration entity                                [error]
"field.field.node.article.field_domain_all_affiliates"
Unexpected error during import with operation create for                 [error]
field.field.node.article.field_domain_all_affiliates: Attempt to
create a field field_domain_all_affiliates that does not exist on
entity type node.
Deleted and replaced configuration entity                                [error]
"field.field.node.article.field_domain_access"
Unexpected error during import with operation create for                 [error]
field.field.node.article.field_domain_access: Attempt to create a
field field_domain_access that does not exist on entity type node.
```