### PR TITLE
Error handling in DomainAliasForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,8 @@ marked with [x] are considered complete.
 - [x] Proper tests for domain record validation
 - [x] Check test logic in testDomainAliasNegotiator()
 - [x] Test that sort logic in DomainAliasLoader matches what is documented
-- [ ] Error handling in DomainAliasForm
-- [ ] Error checking in DomainAliasController
+- [x] Error handling in DomainAliasForm
+- [x] Error checking in DomainAliasController
 - [ ] Deprecated methods in DomainAliasController
 - [ ] Error reporting in `domain_alias_domain_request_alter()`
 - [ ] Ensure completeness of DomainAccessPermissionsTest

--- a/domain_alias/src/DomainAliasForm.php
+++ b/domain_alias/src/DomainAliasForm.php
@@ -11,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 class DomainAliasForm extends EntityForm {
 
   /**
-   * Overrides Drupal\Core\Entity\EntityForm::form().
+   * {@inheritdoc}
    */
   public function form(array $form, FormStateInterface $form_state) {
     /** @var \Drupal\domain_alias\DomainAliasInterface $alias */
@@ -63,42 +63,31 @@ class DomainAliasForm extends EntityForm {
   }
 
   /**
-   * Overrides \Drupal\Core\Entity\EntityForm::validate().
+   * {@inheritdoc}
    */
-  public function validate(array $form, FormStateInterface $form_state) {
-    $entity = $this->buildEntity($form, $form_state);
+  public function validateForm(array &$form, FormStateInterface $form_state) {
     $validator = \Drupal::service('domain_alias.validator');
-    $errors = $validator->validate($entity);
+    $errors = $validator->validate($this->entity);
     if (!empty($errors)) {
       $form_state->setErrorByName('pattern', $errors);
     }
   }
 
   /**
-   * Overrides Drupal\Core\Entity\EntityForm::save().
+   * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
     /** @var \Drupal\domain_alias\DomainAliasInterface $alias */
     $alias = $this->entity;
-    if ($alias->isNew()) {
-      drupal_set_message($this->t('Domain alias created.'));
+    $edit_link = $alias->toLink($this->t('Edit'), 'edit-form')->toString();
+    if ($alias->save() == SAVED_NEW) {
+      drupal_set_message($this->t('Created new domain alias %name.', array('%name' => $alias->label())));
+      $this->logger('domain_alias')->notice('Created new domain alias %name.', array('%name' => $alias->label(), 'link' => $edit_link));
     }
     else {
-      drupal_set_message($this->t('Domain alias updated.'));
+      drupal_set_message($this->t('Updated domain alias %name.'), array('%name' => $alias->label()));
+      $this->logger('domain_alias')->notice('Updated domain alias %name.', array('%name' => $alias->label(), 'link' => $edit_link));
     }
-    $alias->save();
-    $form_state->setRedirect('domain_alias.admin', array('domain' => $alias->getDomainId()));
-  }
-
-  /**
-   * Overrides Drupal\Core\Entity\EntityForm::delete().
-   */
-  public function delete(array $form, FormStateInterface $form_state) {
-    /** @var \Drupal\domain_alias\DomainAliasInterface $alias */
-    $alias = $this->entity;
-    // @TODO: error handling?
-    $alias->delete();
-
     $form_state->setRedirect('domain_alias.admin', array('domain' => $alias->getDomainId()));
   }
 

--- a/domain_alias/src/Form/DomainAliasDeleteForm.php
+++ b/domain_alias/src/Form/DomainAliasDeleteForm.php
@@ -2,45 +2,21 @@
 
 namespace Drupal\domain_alias\Form;
 
-use Drupal\Core\Entity\EntityConfirmFormBase;
-use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\EntityDeleteForm;
 use Drupal\Core\Url;
 
 /**
  * Builds the form to delete a domain_alias record.
  */
-class DomainAliasDeleteForm extends EntityConfirmFormBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getQuestion() {
-    return $this->t('Are you sure you want to delete %name?', array('%name' => $this->entity->label()));
-  }
+class DomainAliasDeleteForm extends EntityDeleteForm {
 
   /**
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    $arguments['domain'] = $this->entity->getDomainId();
-    return new Url('domain_alias.admin', $arguments);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getConfirmText() {
-    return $this->t('Delete');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submit(array $form, FormStateInterface $form_state) {
-    $this->entity->delete();
-    drupal_set_message($this->t('DomainAlias %label has been deleted.', array('%label' => $this->entity->label())));
-    \Drupal::logger('domain_alias')->notice('DomainAlias %label has been deleted.', array('%label' => $this->entity->label()));
-    $form_state->setRedirectUrl($this->getCancelUrl());
+    return new Url('domain_alias.admin', [
+      'domain' => $this->entity->getDomainId(),
+    ]);
   }
 
 }


### PR DESCRIPTION
Also makes `DomainAliasDeleteForm` inline with core

Closes #162