### PR TITLE
Deprecated methods in DomainAliasController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ marked with [x] are considered complete.
 - [x] Test that sort logic in DomainAliasLoader matches what is documented
 - [ ] Error handling in DomainAliasForm
 - [ ] Error checking in DomainAliasController
-- [ ] Deprecated methods in DomainAliasController
+- [x] Deprecated methods in DomainAliasController
 - [ ] Error reporting in `domain_alias_domain_request_alter()`
 - [ ] Ensure completeness of DomainAccessPermissionsTest
 - [ ] Check module setup behavior in tests

--- a/domain_alias/src/Controller/DomainAliasController.php
+++ b/domain_alias/src/Controller/DomainAliasController.php
@@ -2,13 +2,13 @@
 
 namespace Drupal\domain_alias\Controller;
 
+use Drupal\Core\Controller\ControllerBase;
 use Drupal\domain\DomainInterface;
-use Drupal\domain\Controller\DomainControllerBase;
 
 /**
  * Returns responses for Domain Alias module routes.
  */
-class DomainAliasController extends DomainControllerBase {
+class DomainAliasController extends ControllerBase {
 
   /**
    * Provides the domain alias submission form.
@@ -24,7 +24,7 @@ class DomainAliasController extends DomainControllerBase {
     // the parent domain entity.
     $values['domain_id'] = $domain->id();
     // @TODO: ensure that this value is present in all cases.
-    $alias = \Drupal::entityTypeManager()->getStorage('domain_alias')->create($values);
+    $alias = $this->entityTypeManager()->getStorage('domain_alias')->create($values);
 
     return $this->entityFormBuilder()->getForm($alias);
   }
@@ -39,7 +39,7 @@ class DomainAliasController extends DomainControllerBase {
    *   A render array as expected by drupal_render().
    */
   public function listing(DomainInterface $domain) {
-    $list = \Drupal::entityTypeManager()->getListBuilder('domain_alias');
+    $list = $this->entityTypeManager()->getListBuilder('domain_alias');
     $list->setDomain($domain);
     return $list->render();
   }


### PR DESCRIPTION
- Use ControllerBase cos no specific services injected
- Convert usage of \Drupal::entityTypeManager()

Closes #160