### PR TITLE
Migrate files for Domain records D7 -> D8

### DIFF
--- a/domain/migration_templates/d7_domain.yml
+++ b/domain/migration_templates/d7_domain.yml
@@ -1,0 +1,17 @@
+id: d7_domain
+label: Domain Records
+migration_tags:
+  - Drupal 7
+source:
+  plugin: d7_domain
+process:
+  id: machine_name
+  name: sitename
+  hostname: subdomain
+  weight: weight
+  is_default: is_default
+  scheme: scheme
+  path: subdomain
+  status: valid
+destination:
+  plugin: entity:domain

--- a/domain/src/Plugin/migrate/source/d7/DomainRecord.php
+++ b/domain/src/Plugin/migrate/source/d7/DomainRecord.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\domain\Plugin\migrate\source\d7;
+
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
+
+/**
+ * Drupal 7 Domain source from database.
+ *
+ * @MigrateSource(
+ *   id = "d7_domain"
+ * )
+ */
+class DomainRecord extends DrupalSqlBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $fields = [
+      'domain_id',
+      'subdomain',
+      'sitename',
+      'scheme',
+      'valid',
+      'weight',
+      'is_default',
+      'machine_name',
+    ];
+    return $this->select('domain', 'd')->fields('d', $fields);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    return [
+      'domain_id' => $this->t('Domain ID.'),
+      'subdomain' => $this->t('Subdomain.'),
+      'sitename' => $this->t('Sitename.'),
+      'scheme' => $this->t('Scheme.'),
+      'valid' => $this->t('Valid.'),
+      'weight' => $this->t('Weight.'),
+      'is_default' => $this->t('Is default.'),
+      'machine_name' => $this->t('Machine name.'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return ['domain_id' => ['type' => 'int']];
+  }
+
+}


### PR DESCRIPTION
This PR contains a migration template and source to enable migrate from Drupal 7 to Drupal 8 domain records.