### PR TITLE
Fix error when getting user domains for anonymous user

### DIFF
--- a/domain_access/src/DomainAccessManager.php
+++ b/domain_access/src/DomainAccessManager.php
@@ -52,7 +52,7 @@ class DomainAccessManager implements DomainAccessManagerInterface {
       return $list;
     }
     // Get the values of an entity.
-    $values = $entity->get($field_name);
+    $values = $entity->hasField($field_name) ? $entity->get($field_name) : NULL;
     // Must be at least one item.
     if (!empty($values)) {
       foreach ($values as $item) {


### PR DESCRIPTION
I get to this error when installing a new site using config_installer. During this process node access are checked for anonymous user which doesn't have the field_domain_access so it was triggering an InvalidArgumentException.
Then I'm adding a validation to check the entity to have the field before getting it.