### PR TITLE
Better handling of default domain access values.

### DIFF
--- a/domain/src/DomainElementManager.php
+++ b/domain/src/DomainElementManager.php
@@ -95,6 +95,7 @@ class DomainElementManager implements DomainElementManagerInterface {
   public static function submitEntityForm(array &$form, FormStateInterface $form_state) {
     $fields = $form_state->getValue('domain_hidden_fields');
     foreach ($fields as $field) {
+      $entity_values = [];
       $values = $form_state->getValue($field . '_disallowed');
       if (!empty($values)) {
         $info = $form_state->getBuildInfo();
@@ -140,7 +141,7 @@ class DomainElementManager implements DomainElementManagerInterface {
    */
   public function getFieldValues($entity, $field_name) {
     // @TODO: static cache.
-    $list = array();
+    $list = [];
     // @TODO In tests, $entity is returning NULL.
     if (is_null($entity)) {
       return $list;

--- a/domain/tests/src/Functional/DomainReferencesTest.php
+++ b/domain/tests/src/Functional/DomainReferencesTest.php
@@ -52,9 +52,8 @@ class DomainReferencesTest extends DomainTestBase {
     $this->fillField('pass[pass1]', 'test');
     $this->fillField('pass[pass2]', 'test');
 
-    // We expect to find 5 domain options. We set two as selected.
+    // We expect to find 5 domain options. We set three as selected.
     $domains = \Drupal::service('domain.loader')->loadMultiple();
-    $count = 0;
     $ids = ['example_com', 'one_example_com', 'two_example_com'];
     foreach ($domains as $domain) {
       $locator = DOMAIN_ADMIN_FIELD . '[' . $domain->id() . ']';
@@ -76,10 +75,13 @@ class DomainReferencesTest extends DomainTestBase {
 
     $storage = \Drupal::entityTypeManager()->getStorage('user');
     $user = $storage->load(3);
-    // Check that two values are set.
+    // Check that three values are set.
     $manager = \Drupal::service('domain.element_manager');
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
     $this->assert(count($values) == 3, 'User saved with three domain records.');
+    // Check that no access fields are set.
+    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 0, 'User saved with no domain records.');
 
     // Now login as a user with limited rights.
     $account = $this->drupalCreateUser(array(
@@ -91,9 +93,14 @@ class DomainReferencesTest extends DomainTestBase {
     $tester = $storage->load($account->id());
     $values = $manager->getFieldValues($tester, DOMAIN_ADMIN_FIELD);
     $this->assert(count($values) == 2, 'User saved with two domain records.');
+    // Check that no access fields are set.
+    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 0, 'User saved with no domain records.');
+
     $storage->resetCache(array($account->id()));
     $this->drupalLogin($account);
 
+    // Now edit user 3 with limited rights.
     $this->drupalGet('user/' . $user->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
 
@@ -128,6 +135,9 @@ class DomainReferencesTest extends DomainTestBase {
     // Check that two values are set.
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
     $this->assert(count($values) == 2, 'User saved with two domain records.');
+    // Check that no access fields are set.
+    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 0, 'User saved with no domain records.');
 
     // Now login as a user with different limited rights.
     $account = $this->drupalCreateUser(array(
@@ -148,6 +158,7 @@ class DomainReferencesTest extends DomainTestBase {
     $storage->resetCache(array($account->id()));
     $this->drupalLogin($account);
 
+    // Now edit the user as someone with limited rights.
     $this->drupalGet('user/' . $user->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
 
@@ -189,7 +200,7 @@ class DomainReferencesTest extends DomainTestBase {
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
     $this->assert(count($values) == 2, 'User saved with two domain records.');
     $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 3, 'User saved with three domain records.');
+    $this->assert(count($values) == 2, 'User saved with two domain records.'. var_dump($values));
 
   }
 

--- a/domain/tests/src/Functional/DomainReferencesTest.php
+++ b/domain/tests/src/Functional/DomainReferencesTest.php
@@ -35,18 +35,20 @@ class DomainReferencesTest extends DomainTestBase {
    * Basic test setup.
    */
   public function testDomainReferences() {
+    // Create an admin user. This will be user 2.
     $admin = $this->drupalCreateUser(array(
       'bypass node access',
       'administer content types',
       'administer users',
       'administer domains',
+      'assign domain editors',
     ));
     $this->drupalLogin($admin);
 
     $this->drupalGet('admin/people/create');
     $this->assertSession()->statusCodeEquals(200);
 
-    // Create a user through the form.
+    // Create a user through the form. This will be user 3.
     $this->fillField('name', 'testuser');
     $this->fillField('mail', 'test@example.com');
     $this->fillField('pass[pass1]', 'test');
@@ -55,6 +57,7 @@ class DomainReferencesTest extends DomainTestBase {
     // We expect to find 5 domain options. We set three as selected.
     $domains = \Drupal::service('domain.loader')->loadMultiple();
     $ids = ['example_com', 'one_example_com', 'two_example_com'];
+    $edit_ids = ['example_com', 'one_example_com'];
     foreach ($domains as $domain) {
       $locator = DOMAIN_ADMIN_FIELD . '[' . $domain->id() . ']';
       $this->findField($locator);
@@ -63,6 +66,9 @@ class DomainReferencesTest extends DomainTestBase {
       }
       $locator = DOMAIN_ACCESS_FIELD . '[' . $domain->id() . ']';
       $this->findField($locator);
+      if (in_array($domain->id(), $edit_ids)) {
+        $this->checkField($locator);
+      }
     }
 
     // Find the all affiliates field.
@@ -73,35 +79,35 @@ class DomainReferencesTest extends DomainTestBase {
     $this->pressButton('edit-submit');
     $this->assertSession()->statusCodeEquals(200);
 
+    // Load our test user.
     $storage = \Drupal::entityTypeManager()->getStorage('user');
-    $user = $storage->load(3);
+    $testuser = $storage->load(3);
     // Check that three values are set.
     $manager = \Drupal::service('domain.element_manager');
-    $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 3, 'User saved with three domain records.');
+    $values = $manager->getFieldValues($testuser, DOMAIN_ADMIN_FIELD);
+    $this->assert(count($values) == 3, 'User saved with three domain admin records.');
     // Check that no access fields are set.
-    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 0, 'User saved with no domain records.');
+    $values = $manager->getFieldValues($testuser, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain access records.');
 
-    // Now login as a user with limited rights.
+    // Now login as a user with limited rights. This is user 4.
     $account = $this->drupalCreateUser(array(
       'administer users',
       'assign domain administrators',
     ));
+    // Set some domain assignments for this user.
     $ids = ['example_com', 'one_example_com'];
     $this->addDomainsToEntity('user', $account->id(), $ids, DOMAIN_ADMIN_FIELD);
-    $tester = $storage->load($account->id());
-    $values = $manager->getFieldValues($tester, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $limited_admin = $storage->load($account->id());
+    $values = $manager->getFieldValues($limited_admin, DOMAIN_ADMIN_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
     // Check that no access fields are set.
-    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 0, 'User saved with no domain records.');
+    $values = $manager->getFieldValues($limited_admin, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 0, 'User saved with no domain access records.');
 
-    $storage->resetCache(array($account->id()));
+    // Now edit user 3 as user 4 with limited rights.
     $this->drupalLogin($account);
-
-    // Now edit user 3 with limited rights.
-    $this->drupalGet('user/' . $user->id() . '/edit');
+    $this->drupalGet('user/' . $testuser->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
 
     foreach ($domains as $domain) {
@@ -130,36 +136,37 @@ class DomainReferencesTest extends DomainTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Now, check the user.
-    $storage->resetCache(array($user->id()));
-    $user = $storage->load($user->id());
+    $storage->resetCache(array($testuser->id()));
+    $testuser = $storage->load($testuser->id());
     // Check that two values are set.
-    $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $values = $manager->getFieldValues($testuser, DOMAIN_ADMIN_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
     // Check that no access fields are set.
-    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 0, 'User saved with no domain records.');
+    $values = $manager->getFieldValues($testuser, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain access records.');
 
-    // Now login as a user with different limited rights.
-    $account = $this->drupalCreateUser(array(
+    // Now login as a user with different limited rights. This is user 5.
+    $new_account = $this->drupalCreateUser(array(
       'administer users',
       'assign domain administrators',
       'assign domain editors',
     ));
     $ids = ['example_com', 'one_example_com'];
-    $this->addDomainsToEntity('user', $account->id(), $ids, DOMAIN_ADMIN_FIELD);
     $new_ids = ['one_example_com', 'four_example_com'];
-    $this->addDomainsToEntity('user', $account->id(), $new_ids, DOMAIN_ACCESS_FIELD);
+    $this->addDomainsToEntity('user', $new_account->id(), $ids, DOMAIN_ADMIN_FIELD);
+    $this->addDomainsToEntity('user', $new_account->id(), $new_ids, DOMAIN_ACCESS_FIELD);
 
-    $tester = $storage->load($account->id());
-    $values = $manager->getFieldValues($tester, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
-    $values = $manager->getFieldValues($tester, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
-    $storage->resetCache(array($account->id()));
-    $this->drupalLogin($account);
+    $new_admin = $storage->load($new_account->id());
+    $values = $manager->getFieldValues($new_admin, DOMAIN_ADMIN_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
+    $values = $manager->getFieldValues($new_admin, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain access records.');
 
     // Now edit the user as someone with limited rights.
-    $this->drupalGet('user/' . $user->id() . '/edit');
+    $storage->resetCache(array($new_admin->id()));
+    $this->drupalLogin($new_account);
+
+    $this->drupalGet('user/' . $testuser->id() . '/edit');
     $this->assertSession()->statusCodeEquals(200);
 
     foreach ($domains as $domain) {
@@ -174,7 +181,8 @@ class DomainReferencesTest extends DomainTestBase {
       else {
         $this->assertSession()->fieldNotExists($locator);
       }
-      // Some Domain Access field rights exist for this user. This adds one to the count.
+      // Some Domain Access field rights exist for this user. This adds
+      // one to the count.
       $locator = DOMAIN_ACCESS_FIELD . '[' . $domain->id() . ']';
       if (in_array($domain->id(), $new_ids)) {
         $this->findField($locator);
@@ -194,13 +202,13 @@ class DomainReferencesTest extends DomainTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Now, check the user.
-    $storage->resetCache(array($user->id()));
-    $user = $storage->load($user->id());
+    $storage->resetCache(array($testuser->id()));
+    $testuser = $storage->load($testuser->id());
     // Check that two values are set.
-    $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
-    $values = $manager->getFieldValues($user, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.'. var_dump($values));
+    $values = $manager->getFieldValues($testuser, DOMAIN_ADMIN_FIELD);
+    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
+    $values = $manager->getFieldValues($testuser, DOMAIN_ACCESS_FIELD);
+    $this->assert(count($values) == 3, 'User saved with three domain access records.');
 
   }
 

--- a/domain_access/src/DomainAccessManager.php
+++ b/domain_access/src/DomainAccessManager.php
@@ -46,7 +46,7 @@ class DomainAccessManager implements DomainAccessManagerInterface {
    */
   public static function getAccessValues(EntityInterface $entity, $field_name = DOMAIN_ACCESS_FIELD) {
     // @TODO: static cache.
-    $list = array();
+    $list = [];
     // @TODO In tests, $entity is returning NULL.
     if (is_null($entity)) {
       return $list;
@@ -70,7 +70,7 @@ class DomainAccessManager implements DomainAccessManagerInterface {
    * @inheritdoc
    */
   public function getAllValue(EntityInterface $entity) {
-    return $entity->get(DOMAIN_ACCESS_ALL_FIELD)->value;
+    return $entity->hasField(DOMAIN_ACCESS_ALL_FIELD) ? $entity->get(DOMAIN_ACCESS_ALL_FIELD)->value : NULL;
   }
 
   /**
@@ -90,25 +90,19 @@ class DomainAccessManager implements DomainAccessManagerInterface {
    * @inheritdoc
    */
   public static function getDefaultValue(FieldableEntityInterface $entity, FieldDefinitionInterface $definition) {
-    $item = array();
-    switch ($entity->getEntityType()->id()) {
-      case 'user':
-      case 'node':
-        if ($entity->isNew()) {
-          /** @var \Drupal\domain\DomainInterface $active */
-          if ($active = \Drupal::service('domain.negotiator')->getActiveDomain()) {
-            $item[0]['target_uuid'] = $active->uuid();
-          }
-        }
-        // This code does not fire, but it should.
-        else {
-          foreach (self::getAccessValues($entity) as $id) {
-            $item[] = $id;
-          }
-        }
-        break;
-      default:
-        break;
+    $item = [];
+    if (!$entity->isNew()) {
+      // If set, ensure we do not drop existing data.
+      foreach (self::getAccessValues($entity) as $id) {
+        $item[] = $id;
+      }
+    }
+    // When creating a new entity, populate if required.
+    elseif ($entity->getFieldDefinition(DOMAIN_ACCESS_FIELD)->isRequired()) {
+      /** @var \Drupal\domain\DomainInterface $active */
+      if ($active = \Drupal::service('domain.negotiator')->getActiveDomain()) {
+        $item[0]['target_uuid'] = $active->uuid();
+      }
     }
     return $item;
   }


### PR DESCRIPTION
I spun up a PR from #367. I think this logic is sound, In plain terms it says:

* If this entity is not new, return its existing values.
* If this entity is new, set the default value to the active domain If the field is required.

That should remove the need for a switch statement and account for sites that change the field's default behavior.