### PR TITLE
Add missing domain_source.views.schema.yml for domain_source filter

### DIFF
--- a/domain_source/config/schema/domain_source.views.schema.yml
+++ b/domain_source/config/schema/domain_source.views.schema.yml
@@ -1,0 +1,9 @@
+views.field.domain_source:
+  type: views_field
+  label: 'Domain source'
+views.filter.domain_source:
+  type: views.filter.in_operator
+  label: 'Domain source'
+views.filter_value.domain_source:
+  type: views.filter_value.in_operator
+  label: 'Domain source'


### PR DESCRIPTION
The domain_source.views.schema.yml file is required by views, otherwise it does not seem to know what to do with a field_domain_source_target_id filter.