### PR TITLE
Check whether Domain Access is installed before checking DOMAIN_ACCESS_FIELD

### DIFF
--- a/domain_source/domain_source.module
+++ b/domain_source/domain_source.module
@@ -197,8 +197,9 @@ function domain_source_form_node_form_alter(&$form, FormStateInterface $form_sta
   $manager = \Drupal::service('domain_source.element_manager');
   $hide = TRUE;
   $form = $manager->setFormOptions($form, $form_state, DOMAIN_SOURCE_FIELD, $hide);
-  // Add validation if Domain Access is installed.
-  if (defined('DOMAIN_ACCESS_FIELD') && isset($form[DOMAIN_ACCESS_FIELD])) {
+  // Check that our field is present and add validation if Domain Access is
+  // installed. See https://www.drupal.org/node/2952535.
+  if (isset($form[DOMAIN_SOURCE_FIELD]) && defined('DOMAIN_ACCESS_FIELD') && isset($form[DOMAIN_ACCESS_FIELD])) {
     $form[DOMAIN_SOURCE_FIELD]['#element_validate'] = ['domain_source_form_validate'];
     // If using a select field, load the JS to show/hide options.
     if ($form[DOMAIN_SOURCE_FIELD]['widget']['#type'] == 'select') {


### PR DESCRIPTION
Supplementing https://www.drupal.org/project/domain/issues/2952535.

This is just a reroll, which I have tested to the best of my knowledge:

- Created site with two domains active;
- Created two nodes, one on each domain;
- Form Edit both nodes & check both watchdog log and webserver logs for errors;
- Disable Domain Content and then Domain Access modules;
- Form Edit both nodes & check both watchdog log and webserver logs for errors;

No errors noted.