### PR TITLE
Note exceptions thrown; improve doc of options_select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,6 @@ marked with [x] are considered complete.
 - [ ] Caching strategies in DomainNegotiator
 - [ ] Caching strategies in DomainConfigOverrides
 - [ ] Cache in the DomainAccessManager
-- [ ] Add filter options to domain_access and domain_source views
 - [ ] Proper handling of default node values
 - [ ] Do not allow actions to be edited?
 - [o] Recreate the Domain Theme module -- see https://www.drupal.org/project/domain_theme_switch

--- a/domain_config/README.md
+++ b/domain_config/README.md
@@ -45,9 +45,9 @@ langcode: en
 default_langcode: en
 ```
 
-An override file should contain only the specific data that you want to override.
-To override the name, the only line needed is the one beginning ```name:```.
-The resulting override looks like this:
+An override file should contain only the specific data that you want to
+override. To override the name, the only line needed is the one beginning
+ ```name:```. The resulting override looks like this:
 
 ```YAML
 name: Three
@@ -84,13 +84,23 @@ settings.php overrides
 ----------------------
 
 For environment-specific or sensitive overrides, use the settings.php method.
-In the above case, add
-`$config['domain.config.three_example_com.en.system.site']['name'] = "My special site";`
-to your local settings.php file. This will ensure that the `three.example.com`
-domain gets the correct value regardless of other module overrides.
+In the above case, add:
 
-Read more about the "Configuration override system"
-at https://www.drupal.org/node/1928898.
+`$config['domain.config.three_example_com.en.system.site']['name'] = "My special site";`
+
+to your local settings.php file. This will ensure that the `three.example.com`
+domain gets the correct value regardless of other module overrides. If you do
+not have a language set the config system will fallback on the domain-specific
+setting (note the missing '.en'):
+
+`$config['domain.config.three_example_com.system.site']['name'] = "My special site";`
+
+To set nested values you need to nest the config array:
+
+`$config['domain.config.three_example_com.system.site']['page']['front'] = '/node/1;`
+
+Read more about the "Configuration override system" at
+https://www.drupal.org/node/1928898.
 
 Installation
 ============

--- a/domain_source/domain_source.module
+++ b/domain_source/domain_source.module
@@ -23,6 +23,9 @@ const DOMAIN_SOURCE_FIELD = 'field_domain_source';
  * @param string $bundle
  *   The bundle being created.
  *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ *
  * @see domain_source_node_type_insert()
  * @see domain_source_install()
  */
@@ -54,7 +57,11 @@ function domain_source_confirm_fields($entity_type, $bundle) {
   }
 
   // Tell the form system how to behave. Default to radio buttons.
-  if ($display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load($entity_type . '.' .  $bundle . '.default')) {
+  /** @var $display \Drupal\Core\Entity\Display\EntityDisplayInterface */
+  $display = \Drupal::entityTypeManager()
+                    ->getStorage('entity_form_display')
+                    ->load($entity_type . '.' . $bundle . '.default');
+  if ($display) {
     $display->setComponent(DOMAIN_SOURCE_FIELD, [
       'type' => 'options_select',
       'weight' => 42,


### PR DESCRIPTION
Phpstorm noted that that `domain_source_confirm_fields()` threw undocumented exceptions.

There was also a lack of clarity around the code "Tell the form system how to behave. Default to radio buttons." which I have restructured and added a type hint to so that `setComponent()` is findable.

I also wondered whether `\Drupal::entityTypeManager()` can be changed to something like: `\Drupal::service('entity_type.manager')` as done in `domain_source_get()` lower down. 

Let me know if this sort of change is not appropriate ... in particular not sure what the policy around documenting exceptions is.