### PR TITLE
Convert calls to service('entity_type.manager') to entityTypeManager() for consistency

### DIFF
--- a/domain/domain.api.php
+++ b/domain/domain.api.php
@@ -132,7 +132,7 @@ function hook_domain_validate_alter(&$error_list, $hostname) {
 function hook_domain_references_alter($query, $account, $context) {
   // Remove the default domain from non-admins when editing nodes.
   if ($context['entity_type'] == 'node' && $context['field_type'] == 'editor' && !$account->hasPermission('edit assigned domains')) {
-    $default = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultId();
+    $default = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultId();
     $query->condition('id', $default, '<>');
   }
 }

--- a/domain/domain.drush.inc
+++ b/domain/domain.drush.inc
@@ -171,7 +171,7 @@ function domain_drush_help($section) {
  * Shows the domain list.
  */
 function drush_domain_list() {
-  $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultipleSorted(NULL, TRUE);
+  $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultipleSorted(NULL, TRUE);
 
   if (empty($domains)) {
     drush_print(dt('No domains have been created. Use drush domain-add to create one.'));
@@ -219,7 +219,7 @@ function drush_domain_list() {
 function drush_domain_generate_domains($primary = 'example.com') {
   // Check the number of domains to create.
   $count = drush_get_option('count');
-  $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+  $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
   if (empty($count)) {
     $count = 15;
   }
@@ -281,9 +281,9 @@ function drush_domain_generate_domains($primary = 'example.com') {
       'status' => 1,
       'weight' => ($item != $primary) ? $key + $start_weight + 1 : -1,
       'is_default' => 0,
-      'id' => \Drupal::service('entity_type.manager')->getStorage('domain')->createMachineName($hostname),
+      'id' => \Drupal::entityTypeManager()->getStorage('domain')->createMachineName($hostname),
     );
-    $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->create($values);
+    $domain = \Drupal::entityTypeManager()->getStorage('domain')->create($values);
     domain_drush_create($domain);
   }
 
@@ -324,7 +324,7 @@ function drush_domain_add($hostname, $name) {
   $start_weight = $records_count + 1;
   $hostname = mb_strtolower($hostname);
   /** @var \Drupal\domain\DomainStorageInterface $domain_storage */
-  $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+  $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
   $values = array(
     'hostname' => $hostname,
     'name' => $name,
@@ -355,7 +355,7 @@ function drush_domain_add_validate($hostname, $name) {
   if (!empty($errors)) {
     return drush_set_error('domain', $errors);
   }
-  elseif (\Drupal::service('entity_type.manager')->getStorage('domain')->loadByHostname($hostname)) {
+  elseif (\Drupal::entityTypeManager()->getStorage('domain')->loadByHostname($hostname)) {
     return drush_set_error('domain', dt('The hostname is already registered.'));
   }
   return TRUE;
@@ -442,7 +442,7 @@ function drush_domain_delete($argument = NULL) {
     drush_set_error('domain', dt('You must specify a domain to delete.'));
   }
   if ($argument == 'all') {
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
     if (empty($domains)) {
       drush_print(dt('There are no domains to delete.'));
       return;
@@ -470,7 +470,7 @@ function drush_domain_delete($argument = NULL) {
   return;
 
   // TODO: Set options for re-assigning content.
-  $list = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+  $list = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
   $options = array('0' => dt('Do not reassign'));
   foreach ($list as $data) {
     if ($data->id() != $domain->id()) {
@@ -505,7 +505,7 @@ function drush_domain_test($argument = NULL) {
     $GLOBALS['base_path'] = '/' . $base_path . '/';
   }
   if (is_null($argument)) {
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
   }
   else {
     if ($domain = drush_domain_get_from_argument($argument)) {
@@ -589,7 +589,7 @@ function drush_domain_name($argument, $name) {
  * Changes a domain machine_name.
  */
 function drush_domain_machine_name($argument, $machine_name) {
-  $machine_name = \Drupal::service('entity_type.manager')->getStorage('domain')->createMachineName($machine_name);
+  $machine_name = \Drupal::entityTypeManager()->getStorage('domain')->createMachineName($machine_name);
   // Resolve the domain.
   if ($domain = drush_domain_get_from_argument($argument)) {
     $results = \Drupal::entityTypeManager()
@@ -629,9 +629,9 @@ function drush_domain_scheme($argument) {
  * On failure, throws a drush error.
  */
 function drush_domain_get_from_argument($argument) {
-  $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->load($argument);
+  $domain = \Drupal::entityTypeManager()->getStorage('domain')->load($argument);
   if (!$domain) {
-    $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->loadByHostname($argument);
+    $domain = \Drupal::entityTypeManager()->getStorage('domain')->loadByHostname($argument);
   }
   if (!$domain) {
     drush_set_error('domain', dt('Domain record not found.'));

--- a/domain/src/DomainCreator.php
+++ b/domain/src/DomainCreator.php
@@ -51,7 +51,7 @@ class DomainCreator implements DomainCreatorInterface {
       $values['name'] = \Drupal::config('system.site')->get('name');
     }
     $values += array(
-      'scheme' => \Drupal::service('entity_type.manager')->getStorage('domain')->getDefaultScheme(),
+      'scheme' => \Drupal::entityTypeManager()->getStorage('domain')->getDefaultScheme(),
       'status' => 1,
       'weight' => count($domains) + 1,
       'is_default' => (int) empty($default),

--- a/domain/src/Entity/Domain.php
+++ b/domain/src/Entity/Domain.php
@@ -154,7 +154,7 @@ class Domain extends ConfigEntityBase implements DomainInterface {
    */
   public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
     parent::preCreate($storage_controller, $values);
-    $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
     $default = $domain_storage->loadDefaultId();
     $count = $storage_controller->getQuery()->count()->execute();
     $values += array(
@@ -210,7 +210,7 @@ class Domain extends ConfigEntityBase implements DomainInterface {
     if (!$this->isDefault()) {
       // Swap the current default.
       /** @var self $default */
-      if ($default = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultDomain()) {
+      if ($default = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultDomain()) {
         $default->is_default = FALSE;
         $default->setHostname($default->getCanonical());
         $default->save();
@@ -425,7 +425,7 @@ class Domain extends ConfigEntityBase implements DomainInterface {
   public function getScheme($add_suffix = TRUE) {
     $scheme = $this->scheme;
     if ($scheme == 'variable') {
-      $scheme = \Drupal::service('entity_type.manager')->getStorage('domain')->getDefaultScheme();
+      $scheme = \Drupal::entityTypeManager()->getStorage('domain')->getDefaultScheme();
     }
     elseif ($scheme != 'https') {
       $scheme = 'http';

--- a/domain/src/Plugin/Block/DomainNavBlock.php
+++ b/domain/src/Plugin/Block/DomainNavBlock.php
@@ -101,14 +101,14 @@ class DomainNavBlock extends DomainBlockBase {
   public function build() {
     /** @var \Drupal\domain\DomainInterface $active_domain */
     $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
-    $access_handler = \Drupal::service('entity_type.manager')->getAccessControlHandler('domain');
+    $access_handler = \Drupal::entityTypeManager()->getAccessControlHandler('domain');
     $account = \Drupal::currentUser();
 
     // Determine the visible domain list.
     $items = [];
     $add_path = ($this->getSetting('link_options') == 'active');
     /** @var \Drupal\domain\DomainInterface $domain */
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultipleSorted() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultipleSorted() as $domain) {
       // Set the URL.
       $options = ['absolute' => TRUE, 'https' => ($domain->getScheme() == 'https')];
       if ($add_path) {

--- a/domain/src/Plugin/Block/DomainServerBlock.php
+++ b/domain/src/Plugin/Block/DomainServerBlock.php
@@ -43,7 +43,7 @@ class DomainServerBlock extends DomainBlockBase {
     );
     // Check the response test.
     $domain->getResponse();
-    $check = \Drupal::service('entity_type.manager')->getStorage('domain')->loadByHostname($_SERVER['HTTP_HOST']);
+    $check = \Drupal::entityTypeManager()->getStorage('domain')->loadByHostname($_SERVER['HTTP_HOST']);
     $match = $this->t('Exact match');
     // This value is not translatable.
     $environment = 'default';

--- a/domain/src/Plugin/Block/DomainSwitcherBlock.php
+++ b/domain/src/Plugin/Block/DomainSwitcherBlock.php
@@ -31,7 +31,7 @@ class DomainSwitcherBlock extends DomainBlockBase {
     $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
     $items = array();
     /** @var \Drupal\domain\DomainInterface $domain */
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultipleSorted() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultipleSorted() as $domain) {
       $string = $domain->getLink();
       if (!$domain->status()) {
         $string .= '*';

--- a/domain/src/Plugin/Condition/Domain.php
+++ b/domain/src/Plugin/Condition/Domain.php
@@ -65,7 +65,7 @@ class Domain extends ConditionPluginBase implements ContainerFactoryPluginInterf
       '#type' => 'checkboxes',
       '#title' => $this->t('When the following domains are active'),
       '#default_value' => $this->configuration['domains'],
-      '#options' => array_map('\Drupal\Component\Utility\Html::escape', \Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList()),
+      '#options' => array_map('\Drupal\Component\Utility\Html::escape', \Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList()),
       '#description' => $this->t('If you select no domains, the condition will evaluate to TRUE for all requests.'),
       '#attached' => array(
         'library' => array(
@@ -98,7 +98,7 @@ class Domain extends ConditionPluginBase implements ContainerFactoryPluginInterf
    */
   public function summary() {
     // Use the domain labels. They will be sanitized below.
-    $domains = array_intersect_key(\Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList(), $this->configuration['domains']);
+    $domains = array_intersect_key(\Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList(), $this->configuration['domains']);
     if (count($domains) > 1) {
       $domains = implode(', ', $domains);
     }

--- a/domain/tests/src/Functional/Condition/DomainConditionTest.php
+++ b/domain/tests/src/Functional/Condition/DomainConditionTest.php
@@ -46,7 +46,7 @@ class DomainConditionTest extends DomainTestBase {
     $this->domainCreateTestDomains(5);
 
     // Get two sample domains.
-    $this->domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $this->domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $this->test_domain = array_shift($this->domains);
     $this->not_domain = array_shift($this->domains);
   }

--- a/domain/tests/src/Functional/DomainActionsTest.php
+++ b/domain/tests/src/Functional/DomainActionsTest.php
@@ -28,7 +28,7 @@ class DomainActionsTest extends DomainTestBase {
     $this->assertResponse(200);
 
     // Test the domains.
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain');
     $domains = $storage->loadMultiple();
     $this->assertTrue(count($domains) == 4, 'Four domain records found.');
 

--- a/domain/tests/src/Functional/DomainAdminElementTest.php
+++ b/domain/tests/src/Functional/DomainAdminElementTest.php
@@ -50,7 +50,7 @@ class DomainAdminElementTest extends DomainTestBase {
     $this->fillField('pass[pass2]', 'test');
 
     // We expect to find 5 domain options. We set two as selected.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $count = 0;
     $ids = ['example_com', 'one_example_com', 'two_example_com'];
     foreach ($domains as $domain) {

--- a/domain/tests/src/Functional/DomainCSSTest.php
+++ b/domain/tests/src/Functional/DomainCSSTest.php
@@ -40,7 +40,7 @@ class DomainCSSTest extends DomainTestBase {
     $config->set('default', 'bartik')->save();
 
     // Test the response of the default home page.
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
       $text = '<body class="' . Html::getClass($domain->id() . '-class');
       $this->assertNoRaw($text, 'No custom CSS present.');
@@ -50,7 +50,7 @@ class DomainCSSTest extends DomainTestBase {
     $config->set('css_classes', '[domain:machine-name]-class')->save();
 
     // Test the response of the default home page.
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       // The render cache trips up this test. In production, it may be
       // necessary to add the url.site cache context. See README.md.
       drupal_flush_all_caches();
@@ -63,7 +63,7 @@ class DomainCSSTest extends DomainTestBase {
     $config = $this->config('domain.settings');
     $config->set('css_classes', '[domain:machine-name]-class [domain:name]-class')->save();
     // Test the response of the default home page.
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       // The render cache trips up this test. In production, it may be
       // necessary to add the url.site cache context. See README.md.
       drupal_flush_all_caches();

--- a/domain/tests/src/Functional/DomainCheckResponseTest.php
+++ b/domain/tests/src/Functional/DomainCheckResponseTest.php
@@ -18,7 +18,7 @@ class DomainCheckResponseTest extends DomainTestBase {
     $this->admin_user = $this->drupalCreateUser(array('administer domains', 'create domains'));
     $this->drupalLogin($this->admin_user);
 
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain');
 
     // Make a POST request on admin/config/domain/add.
     $edit = $this->domainPostValues();

--- a/domain/tests/src/Functional/DomainCreateTest.php
+++ b/domain/tests/src/Functional/DomainCreateTest.php
@@ -19,7 +19,7 @@ class DomainCreateTest extends DomainTestBase {
     $this->domainTableIsEmpty();
 
     // Create a new domain programmatically.
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain');
     $domain = $storage->create();
     $domain->set('id', $storage->createMachineName($domain->getHostname()));
     foreach (array('id', 'name', 'hostname', 'scheme', 'status', 'weight' , 'is_default') as $key) {

--- a/domain/tests/src/Functional/DomainEntityReferenceTest.php
+++ b/domain/tests/src/Functional/DomainEntityReferenceTest.php
@@ -87,7 +87,7 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $this->assertText('Domain test field', 'Found the domain field instance.');
 
     // We expect to find 5 domain options.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
       $this->assertRaw($string, 'Found the domain option');

--- a/domain/tests/src/Functional/DomainFormsTest.php
+++ b/domain/tests/src/Functional/DomainFormsTest.php
@@ -18,7 +18,7 @@ class DomainFormsTest extends DomainTestBase {
     $this->admin_user = $this->drupalCreateUser(array('administer domains', 'create domains'));
     $this->drupalLogin($this->admin_user);
 
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain');
 
     // No domains should exist.
     $this->domainTableIsEmpty();

--- a/domain/tests/src/Functional/DomainGetResponseTest.php
+++ b/domain/tests/src/Functional/DomainGetResponseTest.php
@@ -24,7 +24,7 @@ class DomainGetResponseTest extends DomainTestBase {
     // Check the created domain based on it's known id value.
     $key = 'example_com';
     /** @var \Drupal\domain\Entity\Domain $domain */
-    $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->load($key);
+    $domain = \Drupal::entityTypeManager()->getStorage('domain')->load($key);
 
     // Our testing server should be able to access the test PNG file.
     $this->assertTrue($domain->getResponse() == 200, 'Server returned a 200 response.');
@@ -35,7 +35,7 @@ class DomainGetResponseTest extends DomainTestBase {
       'id' => 'foo_bar',
       'name' => 'Foo',
     );
-    $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->create($values);
+    $domain = \Drupal::entityTypeManager()->getStorage('domain')->create($values);
 
     $domain->save();
     $this->assertTrue($domain->getResponse() == 500, 'Server test returned a 500 response.');

--- a/domain/tests/src/Functional/DomainInactiveTest.php
+++ b/domain/tests/src/Functional/DomainInactiveTest.php
@@ -30,7 +30,7 @@ class DomainInactiveTest extends DomainTestBase {
 
     // Create four new domains programmatically.
     $this->domainCreateTestDomains(4);
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
 
     // Grab a known domain for testing.
     $domain = $domains['two_example_com'];
@@ -40,7 +40,7 @@ class DomainInactiveTest extends DomainTestBase {
 
     // Disable the domain and test for redirect.
     $domain->disable();
-    $default = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultDomain();
+    $default = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultDomain();
     // Our postSave() cache tag clear should allow this to work properly.
     $this->drupalGet($domain->getPath());
 

--- a/domain/tests/src/Functional/DomainNavBlockTest.php
+++ b/domain/tests/src/Functional/DomainNavBlockTest.php
@@ -25,7 +25,7 @@ class DomainNavBlockTest extends DomainTestBase {
   public function testDomainNav() {
     // Create four new domains programmatically.
     $this->domainCreateTestDomains(4);
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
 
     // Place the nav block.
     $block = $this->drupalPlaceBlock('domain_nav_block');

--- a/domain/tests/src/Functional/DomainNegotiatorTest.php
+++ b/domain/tests/src/Functional/DomainNegotiatorTest.php
@@ -37,7 +37,7 @@ class DomainNegotiatorTest extends DomainTestBase {
     user_role_grant_permissions(AccountInterface::ANONYMOUS_ROLE, array('view domain information'));
 
     // Test the response of the default home page.
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
       $this->assertRaw($domain->label(), 'Loaded the proper domain.');
     }

--- a/domain/tests/src/Functional/DomainReferencesTest.php
+++ b/domain/tests/src/Functional/DomainReferencesTest.php
@@ -55,7 +55,7 @@ class DomainReferencesTest extends DomainTestBase {
     $this->fillField('pass[pass2]', 'test');
 
     // We expect to find 5 domain options. We set three as selected.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
 
     $ids = ['example_com', 'one_example_com', 'two_example_com'];
     $edit_ids = ['example_com', 'one_example_com'];

--- a/domain/tests/src/Functional/DomainTestBase.php
+++ b/domain/tests/src/Functional/DomainTestBase.php
@@ -41,7 +41,7 @@ abstract class DomainTestBase extends BrowserTestBase {
     parent::setUp();
 
     // Set the base hostname for domains.
-    $this->base_hostname = \Drupal::service('entity_type.manager')->getStorage('domain')->createHostname();
+    $this->base_hostname = \Drupal::entityTypeManager()->getStorage('domain')->createHostname();
   }
 
   /**

--- a/domain/tests/src/Functional/DomainTokenTest.php
+++ b/domain/tests/src/Functional/DomainTokenTest.php
@@ -37,7 +37,7 @@ class DomainTokenTest extends DomainTestBase {
     user_role_grant_permissions(AccountInterface::ANONYMOUS_ROLE, array('view domain information'));
 
     // Test the response of the default home page.
-    foreach (\Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple() as $domain) {
+    foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
       $this->assertRaw($domain->label(), 'Loaded the proper domain.');
       $this->assertRaw('<th>Token</th>', 'Token values printed.');

--- a/domain/tests/src/Functional/DomainValidatorTest.php
+++ b/domain/tests/src/Functional/DomainValidatorTest.php
@@ -19,7 +19,7 @@ class DomainValidatorTest extends DomainTestBase {
     // No domains should exist.
     $this->domainTableIsEmpty();
     $validator = \Drupal::service('domain.validator');
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain');
 
     // Create a domain.
     $this->domainCreateTestDomains(1, 'foo.com');

--- a/domain/tests/src/Functional/DomainViewsAccessTest.php
+++ b/domain/tests/src/Functional/DomainViewsAccessTest.php
@@ -31,7 +31,7 @@ class DomainViewsAccessTest extends DomainTestBase {
   public function testInactiveDomain() {
     // Create five new domains programmatically.
     $this->domainCreateTestDomains(5);
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     // Enable the views.
     $this->enableViewsTestModule();
     // Create a user. To test the area output was more difficult, so we just

--- a/domain/tests/src/Kernel/DomainHookTest.php
+++ b/domain/tests/src/Kernel/DomainHookTest.php
@@ -59,7 +59,7 @@ class DomainHookTest extends KernelTestBase {
     $this->domainCreateTestDomains();
 
     // Get the services.
-    $this->domainStorage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $this->domainStorage = \Drupal::entityTypeManager()->getStorage('domain');
     $this->currentUser = \Drupal::service('current_user');
     $this->moduleHandler = \Drupal::service('module_handler');
   }

--- a/domain/tests/src/Kernel/DomainVariableSchemeTest.php
+++ b/domain/tests/src/Kernel/DomainVariableSchemeTest.php
@@ -41,7 +41,7 @@ class DomainVariableSchemeTest extends KernelTestBase {
     $this->domainCreateTestDomains();
 
     // Get the services.
-    $this->domainStorage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $this->domainStorage = \Drupal::entityTypeManager()->getStorage('domain');
   }
 
   /**

--- a/domain/tests/src/Traits/DomainTestTrait.php
+++ b/domain/tests/src/Traits/DomainTestTrait.php
@@ -28,7 +28,7 @@ trait DomainTestTrait {
    *   An optional list of subdomains to apply instead of the default set.
    */
   public function domainCreateTestDomains($count = 1, $base_hostname = NULL, $list = array()) {
-    $original_domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+    $original_domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
     if (empty($base_hostname)) {
       $base_hostname = $this->base_hostname;
     }
@@ -59,12 +59,12 @@ trait DomainTestTrait {
       $values = array(
         'hostname' => $hostname,
         'name' => $name,
-        'id' => \Drupal::service('entity_type.manager')->getStorage('domain')->createMachineName($machine_name),
+        'id' => \Drupal::entityTypeManager()->getStorage('domain')->createMachineName($machine_name),
       );
       $domain = \Drupal::entityTypeManager()->getStorage('domain')->create($values);
       $domain->save();
     }
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
   }
 
   /**
@@ -93,8 +93,8 @@ trait DomainTestTrait {
    *   An array of domain entities.
    */
   public function getDomains() {
-    \Drupal::service('entity_type.manager')->getStorage('domain')->resetCache();
-    return \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    \Drupal::entityTypeManager()->getStorage('domain')->resetCache();
+    return \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
   }
 
   /**
@@ -104,8 +104,8 @@ trait DomainTestTrait {
    *   An array of domain entities.
    */
   public function getDomainsSorted() {
-    \Drupal::service('entity_type.manager')->getStorage('domain')->resetCache();
-    return \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultipleSorted();
+    \Drupal::entityTypeManager()->getStorage('domain')->resetCache();
+    return \Drupal::entityTypeManager()->getStorage('domain')->loadMultipleSorted();
   }
 
   /**
@@ -126,16 +126,16 @@ trait DomainTestTrait {
    * Set the base hostname for this test.
    */
   public function setBaseHostname() {
-    $this->base_hostname = \Drupal::service('entity_type.manager')->getStorage('domain')->createHostname();
+    $this->base_hostname = \Drupal::entityTypeManager()->getStorage('domain')->createHostname();
   }
 
   /**
    * Reusable test function for checking initial / empty table status.
    */
   public function domainTableIsEmpty() {
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(NULL, TRUE);
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(NULL, TRUE);
     $this->assertTrue(empty($domains), 'No domains have been created.');
-    $default_id = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultId();
+    $default_id = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultId();
     $this->assertTrue(empty($default_id), 'No default domain has been set.');
   }
 
@@ -144,14 +144,14 @@ trait DomainTestTrait {
    */
   public function domainPostValues() {
     $edit = array();
-    $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->create();
+    $domain = \Drupal::entityTypeManager()->getStorage('domain')->create();
     $required = \Drupal::service('domain.validator')->getRequiredFields();
     foreach ($required as $key) {
       $edit[$key] = $domain->get($key);
     }
     // URL validation has issues on Travis, so only do it when requested.
     $edit['validate_url'] = 0;
-    $edit['id'] = \Drupal::service('entity_type.manager')->getStorage('domain')->createMachineName($edit['hostname']);
+    $edit['id'] = \Drupal::entityTypeManager()->getStorage('domain')->createMachineName($edit['hostname']);
     return $edit;
   }
 

--- a/domain_access/domain_access.install
+++ b/domain_access/domain_access.install
@@ -29,7 +29,7 @@ function domain_access_install() {
     domain_access_confirm_fields($entity_type, $bundle);
   }
   // Install our actions.
-  $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+  $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
   foreach ($domains as $domain) {
     domain_access_domain_insert($domain);
   }

--- a/domain_access/domain_access.module
+++ b/domain_access/domain_access.module
@@ -33,7 +33,7 @@ function domain_access_node_grants(AccountInterface $account, $op) {
   $active = \Drupal::service('domain.negotiator')->getActiveDomain();
 
   if (empty($active)) {
-    $active = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultDomain();
+    $active = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultDomain();
   }
 
   // No domains means no permissions.
@@ -89,7 +89,7 @@ function domain_access_node_access_records(NodeInterface $node) {
     }
     foreach ($domains as $id => $domainId) {
       /** @var \Drupal\domain\DomainInterface $domain */
-      if ($domain = \Drupal::service('entity_type.manager')->getStorage('domain')->load($id)) {
+      if ($domain = \Drupal::entityTypeManager()->getStorage('domain')->load($id)) {
         $grants[] = array(
           'realm' => ($translation->isPublished()) ? 'domain_id' : 'domain_unpublished',
           'gid' => $domain->getDomainId(),
@@ -167,7 +167,7 @@ function domain_access_presave_generate(EntityInterface $entity) {
     if (isset($entity->devel_generate['domain_access'])) {
       $selection = array_filter($entity->devel_generate['domain_access']);
       if (isset($selection['random-selection'])) {
-        $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+        $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
         $values[DOMAIN_ACCESS_FIELD] = array_rand($domains, ceil(rand(1, count($domains))));
       }
       else {
@@ -199,7 +199,7 @@ function domain_access_form_devel_generate_form_content_alter(&$form, &$form_sta
   // Add our element to the Devel generate form.
   $form['submit']['#weight'] = 10;
   $list = ['random-selection' => t('Random selection')];
-  $list += \Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList();
+  $list += \Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList();
   $form['domain_access'] = array(
     '#title' => t('Domains'),
     '#type' => 'checkboxes',

--- a/domain_access/src/Plugin/Action/DomainAccessActionBase.php
+++ b/domain_access/src/Plugin/Action/DomainAccessActionBase.php
@@ -57,7 +57,7 @@ abstract class DomainAccessActionBase extends ConfigurableActionBase implements 
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList();
     $form['domain_id'] = array(
       '#type' => 'checkboxes',
       '#title' => t('Domain'),

--- a/domain_access/src/Plugin/views/argument/DomainAccessArgument.php
+++ b/domain_access/src/Plugin/views/argument/DomainAccessArgument.php
@@ -15,7 +15,7 @@ class DomainAccessArgument extends StringArgument {
    * {@inheritdoc}
    */
   public function title() {
-    if ($domain = \Drupal::service('entity_type.manager')->getStorage('domain')->load($this->argument)) {
+    if ($domain = \Drupal::entityTypeManager()->getStorage('domain')->load($this->argument)) {
       return $domain->label();
     }
     return parent::title();

--- a/domain_access/src/Plugin/views/filter/DomainAccessFilter.php
+++ b/domain_access/src/Plugin/views/filter/DomainAccessFilter.php
@@ -18,7 +18,7 @@ class DomainAccessFilter extends InOperator {
     // @TODO: filter this list.
     if (!isset($this->valueOptions)) {
       $this->valueTitle = $this->t('Domains');
-      $this->valueOptions = \Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList();
+      $this->valueOptions = \Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList();
     }
     return $this->valueOptions;
   }

--- a/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
@@ -72,7 +72,7 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
     $this->assertText($label, 'Found the domain field instance.');
 
     // We expect to find 5 domain options.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
       $this->assertRaw($string, 'Found the domain option.');

--- a/domain_access/tests/src/Functional/DomainAccessElementTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessElementTest.php
@@ -59,7 +59,7 @@ class DomainAccessElementTest extends DomainTestBase {
     $this->fillField('title[0][value]', 'Test node');
 
     // We expect to find 5 domain options. We set two as selected.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $count = 0;
     $ids = ['example_com', 'one_example_com', 'two_example_com'];
     foreach ($domains as $domain) {

--- a/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
@@ -70,7 +70,7 @@ class DomainAccessEntityReferenceTest extends DomainTestBase {
     $this->assertText('Domain Access', 'Found the domain field instance.');
 
     // We expect to find 5 domain options.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
       $this->assertRaw($string, 'Found the domain option.');

--- a/domain_access/tests/src/Functional/DomainAccessFieldTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessFieldTest.php
@@ -44,7 +44,7 @@ class DomainAccessFieldTest extends DomainTestBase {
     $this->assertResponse(200, 'Article creation found.');
 
     // Check for the form options.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $this->assertText($domain->label(), 'Domain form item found.');
     }
@@ -162,7 +162,7 @@ class DomainAccessFieldTest extends DomainTestBase {
     $this->assertResponse(200, $type->id() . ' creation found.');
 
     // Check for the form options.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $this->assertText($domain->label(), 'Domain form item found.');
     }
@@ -175,7 +175,7 @@ class DomainAccessFieldTest extends DomainTestBase {
     $user_edit_page = 'user/' . $user8->id() . '/edit';
     $this->drupalGet($user_edit_page);
     // Check for the form options.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $this->assertNoText($domain->label(), 'Domain form item not found.');
     }

--- a/domain_access/tests/src/Functional/DomainAccessGrantsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessGrantsTest.php
@@ -45,7 +45,7 @@ class DomainAccessGrantsTest extends DomainTestBase {
     // Create 5 domains.
     $this->domainCreateTestDomains(5);
     // Assign a node to a random domain.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $active_domain = array_rand($domains, 1);
     $domain = $domains[$active_domain];
     // Create an article node.

--- a/domain_access/tests/src/Functional/DomainAccessPermissionsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessPermissionsTest.php
@@ -74,7 +74,7 @@ class DomainAccessPermissionsTest extends DomainTestBase {
     $this->userStorage = \Drupal::entityTypeManager()->getStorage('user');
     // Create 5 domains.
     $this->domainCreateTestDomains(5);
-    $this->domains = $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $this->domains = $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
   }
 
   /**

--- a/domain_access/tests/src/Functional/DomainAccessRecordsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessRecordsTest.php
@@ -26,7 +26,7 @@ class DomainAccessRecordsTest extends DomainTestBase {
     // Create 5 domains.
     $this->domainCreateTestDomains(5);
     // Assign a node to a random domain.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $active_domain = array_rand($domains, 1);
     $domain = $domains[$active_domain];
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');

--- a/domain_alias/domain_alias.module
+++ b/domain_alias/domain_alias.module
@@ -34,8 +34,8 @@ function domain_alias_domain_request_alter(DomainInterface &$domain) {
   }
   // If no exact match, then run the alias load routine.
   $hostname = $domain->getHostname();
-  $alias_storage = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
-  $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+  $alias_storage = \Drupal::entityTypeManager()->getStorage('domain_alias');
+  $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
   /** @var \Drupal\domain_alias\Entity\DomainAlias $alias */
   if ($alias = $alias_storage->loadByHostname($hostname)) {
     /** @var \Drupal\domain\Entity\Domain $domain */
@@ -102,7 +102,7 @@ function domain_alias_domain_load($entities) {
   }
 
   // Load and rewrite environement-specific aliases.
-  $alias_storage = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+  $alias_storage = \Drupal::entityTypeManager()->getStorage('domain_alias');
   if (isset($active->alias) && $active->alias->getEnvironment() != 'default') {
     foreach ($entities as $id => $domain) {
       if ($environment_aliases = $alias_storage->loadByEnvironmentMatch($domain, $active->alias->getEnvironment())) {
@@ -160,7 +160,7 @@ function domain_alias_domain_load($entities) {
  * Implements hook_ENTITY_TYPE_delete().
  */
 function domain_alias_domain_delete(EntityInterface $entity) {
-  $alias_storage = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+  $alias_storage = \Drupal::entityTypeManager()->getStorage('domain_alias');
   $properties = ['domain_id' => $entity->id()];
   foreach ($alias_storage->loadByProperties($properties) as $alias) {
     $alias->delete();

--- a/domain_alias/src/Entity/DomainAlias.php
+++ b/domain_alias/src/Entity/DomainAlias.php
@@ -114,7 +114,7 @@ class DomainAlias extends ConfigEntityBase implements DomainAliasInterface {
    * {@inheritdoc}
    */
   public function getDomain() {
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain');
     $domains = $storage->loadByProperties(['domain_id' => $this->domain_id]);
     return $domains ? current($domains) : NULL;
   }

--- a/domain_alias/tests/src/Functional/DomainAliasActionsTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasActionsTest.php
@@ -35,8 +35,8 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
     // Create test domains.
     $this->domainCreateTestDomains(3);
 
-    $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
-    $alias_loader = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
+    $alias_loader = \Drupal::entityTypeManager()->getStorage('domain_alias');
     $domains = $domain_storage->loadMultiple();
 
     // Save these for later testing.

--- a/domain_alias/tests/src/Functional/DomainAliasEnvironmentTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasEnvironmentTest.php
@@ -33,8 +33,8 @@ class DomainAliasEnvironmentTest extends DomainAliasTestBase {
    * Test for environment matching.
    */
   public function testDomainAliasEnvironments() {
-    $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
-    $alias_loader = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
+    $alias_loader = \Drupal::entityTypeManager()->getStorage('domain_alias');
     $domains = $domain_storage->loadMultipleSorted(NULL, TRUE);
     // Our patterns should map to example.com, one.example.com, two.example.com.
     $patterns = ['*.example.com', 'four.example.com', 'five.example.com'];

--- a/domain_alias/tests/src/Functional/DomainAliasListHostnameTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasListHostnameTest.php
@@ -26,8 +26,8 @@ class DomainAliasListHostnameTest extends DomainAliasTestBase {
    * Test for environment matching.
    */
   public function testDomainAliasEnvironments() {
-    $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
-    $alias_loader = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
+    $alias_loader = \Drupal::entityTypeManager()->getStorage('domain_alias');
     $domains = $domain_storage->loadMultiple();
 
     $base = $this->base_hostname;

--- a/domain_alias/tests/src/Functional/DomainAliasNegotiatorTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasNegotiatorTest.php
@@ -37,8 +37,8 @@ class DomainAliasNegotiatorTest extends DomainAliasTestBase {
     user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, array('administer domains'));
 
     // Set the storage handles.
-    $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
-    $alias_storage = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
+    $alias_storage = \Drupal::entityTypeManager()->getStorage('domain_alias');
 
     // Set known prefixes that work with our tests. This will give us domains
     // 'example.com' and 'one.example.com' aliased to 'two.example.com' and

--- a/domain_alias/tests/src/Functional/DomainAliasSortTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasSortTest.php
@@ -17,7 +17,7 @@ class DomainAliasSortTest extends DomainAliasTestBase {
   public function testAliasSort() {
     $list = $this->sortList();
 
-    $storage = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $storage = \Drupal::entityTypeManager()->getStorage('domain_alias');
     foreach ($list as $key => $values) {
       $patterns = $storage->getPatterns($key);
       $this->assertTrue(empty(array_diff($values, $patterns)), 'Pattern matched as expected for ' . $key);

--- a/domain_alias/tests/src/Functional/DomainAliasValidatorTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasValidatorTest.php
@@ -24,7 +24,7 @@ class DomainAliasValidatorTest extends DomainAliasTestBase {
     // Check the created domain based on it's known id value.
     $key = 'foo.com';
     /** @var \Drupal\domain\Entity\Domain $domain */
-    $domain = \Drupal::service('entity_type.manager')->getStorage('domain')->loadByHostname($key);
+    $domain = \Drupal::entityTypeManager()->getStorage('domain')->loadByHostname($key);
     $this->assertTrue(!empty($domain), 'Test domain created.');
 
     // Valid patterns to test. Valid is the boolean value.

--- a/domain_alias/tests/src/Functional/DomainAliasWildcardTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasWildcardTest.php
@@ -33,8 +33,8 @@ class DomainAliasWildcardTest extends DomainAliasTestBase {
    * Test for environment matching.
    */
   public function testDomainAliasWildcards() {
-    $domain_storage = \Drupal::service('entity_type.manager')->getStorage('domain');
-    $alias_loader = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $domain_storage = \Drupal::entityTypeManager()->getStorage('domain');
+    $alias_loader = \Drupal::entityTypeManager()->getStorage('domain_alias');
     $domains = $domain_storage->loadMultipleSorted(NULL, TRUE);
     // Our patterns should map to example.com, one.example.com, two.example.com.
     $patterns = ['example.*', 'four.example.*', 'five.example.*'];

--- a/domain_alias/tests/src/Kernel/DomainAliasDomainDeleteTest.php
+++ b/domain_alias/tests/src/Kernel/DomainAliasDomainDeleteTest.php
@@ -42,8 +42,8 @@ class DomainAliasDomainDeleteTest extends DomainTestBase {
     $this->domainCreateTestDomains(2);
 
     // Get the services.
-    $this->domainStorage = \Drupal::service('entity_type.manager')->getStorage('domain');
-    $this->aliasStorage = \Drupal::service('entity_type.manager')->getStorage('domain_alias');
+    $this->domainStorage = \Drupal::entityTypeManager()->getStorage('domain');
+    $this->aliasStorage = \Drupal::entityTypeManager()->getStorage('domain_alias');
   }
 
   /**

--- a/domain_config/tests/src/Functional/DomainConfigHomepageTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHomepageTest.php
@@ -31,7 +31,7 @@ class DomainConfigHomepageTest extends DomainConfigTestBase {
     // Create four new domains programmatically.
     $this->domainCreateTestDomains(5);
     // Get the domain list.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $this->drupalCreateNode(array(
       'type' => 'article',
       'title' => 'Node 1',

--- a/domain_config/tests/src/Functional/DomainConfigOverriderTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigOverriderTest.php
@@ -20,7 +20,7 @@ class DomainConfigOverriderTest extends DomainConfigTestBase {
     // Create five new domains programmatically.
     $this->domainCreateTestDomains(5);
     // Get the domain list.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     // Except for the default domain, the page title element should match what
     // is in the override files.
     // With a language context, based on how we have our files setup, we
@@ -63,7 +63,7 @@ class DomainConfigOverriderTest extends DomainConfigTestBase {
 
     // Create five new domains programmatically.
     $this->domainCreateTestDomains(5);
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple(['one_example_com', 'four_example_com']);
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple(['one_example_com', 'four_example_com']);
 
     $domain_one = $domains['one_example_com'];
     $this->drupalGet($domain_one->getPath() . 'user/login');

--- a/domain_content/domain_content.install
+++ b/domain_content/domain_content.install
@@ -4,7 +4,7 @@
  * Implements hook_uninstall().
  */
 function domain_content_uninstall() {
-  $storage = \Drupal::service('entity_type.manager')->getStorage('view');
+  $storage = \Drupal::entityTypeManager()->getStorage('view');
   $entities = [];
   foreach (['affiliated_content', 'affiliated_editors'] as $id) {
     if ($view = $storage->load($id)) {

--- a/domain_content/src/Controller/DomainContentController.php
+++ b/domain_content/src/Controller/DomainContentController.php
@@ -37,7 +37,7 @@ class DomainContentController extends ControllerBase {
       ];
     }
     // Loop through domains.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultipleSorted();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultipleSorted();
     $manager = \Drupal::service('domain_access.manager');
     /** @var \Drupal\domain\DomainInterface $domain */
     foreach ($domains as $domain) {

--- a/domain_content/tests/src/Functional/DomainContentTestBase.php
+++ b/domain_content/tests/src/Functional/DomainContentTestBase.php
@@ -39,7 +39,7 @@ abstract class DomainContentTestBase extends DomainTestBase {
     // Create five test domains.
     $this->domainCreateTestDomains(5);
 
-    $this->domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $this->domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
   }
 
   /**

--- a/domain_source/domain_source.api.php
+++ b/domain_source/domain_source.api.php
@@ -29,7 +29,7 @@
  */
 function hook_domain_source_alter(array &$source, $path, array $options) {
   // Always link to the default domain.
-  $source = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultDomain();
+  $source = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultDomain();
 }
 
 /**
@@ -60,6 +60,6 @@ function hook_domain_source_path_alter(array &$source, $path, array $options) {
   // Always make admin links go to the primary domain.
   $parts = explode('/', $path);
   if (isset($parts[0]) && $parts[0] == 'admin') {
-    $source = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultDomain();
+    $source = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultDomain();
   }
 }

--- a/domain_source/domain_source.module
+++ b/domain_source/domain_source.module
@@ -112,7 +112,7 @@ function domain_source_get(EntityInterface $entity) {
   $value = $entity->get(DOMAIN_SOURCE_FIELD)->offsetGet(0);
   if (!empty($value)) {
     $target_id = $value->target_id;
-    if ($domain = \Drupal::service('entity_type.manager')->getStorage('domain')->load($target_id)) {
+    if ($domain = \Drupal::entityTypeManager()->getStorage('domain')->load($target_id)) {
       $source = $domain->id();
     }
   }
@@ -226,7 +226,7 @@ function domain_source_views_data_alter(array &$data) {
 function domain_source_form_devel_generate_form_content_alter(&$form, &$form_state, $form_id) {
   // Add our element to the Devel generate form.
   $list = ['_derive' => t('Derive from domain selection')];
-  $list += \Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList();
+  $list += \Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList();
   $form['domain_source'] = [
     '#title' => t('Domain source'),
     '#type' => 'checkboxes',
@@ -262,7 +262,7 @@ function domain_source_presave_generate(EntityInterface $entity) {
     if (isset($entity->devel_generate['domain_access'])) {
       $selection = array_filter($entity->devel_generate['domain_access']);
       if (isset($selection['random-selection'])) {
-        $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+        $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
         $selections = array_rand($domains, ceil(rand(1, count($domains))));
       }
       else {

--- a/domain_source/src/Plugin/views/filter/DomainSource.php
+++ b/domain_source/src/Plugin/views/filter/DomainSource.php
@@ -21,7 +21,7 @@ class DomainSource extends InOperator {
       $this->valueTitle = $this->t('Domains');
       $this->valueOptions = [
         '_active' => $this->t('Active domain'),
-      ] + \Drupal::service('entity_type.manager')->getStorage('domain')->loadOptionsList();
+      ] + \Drupal::entityTypeManager()->getStorage('domain')->loadOptionsList();
     }
     return $this->valueOptions;
   }

--- a/domain_source/tests/modules/domain_source_test/domain_source_test.module
+++ b/domain_source/tests/modules/domain_source_test/domain_source_test.module
@@ -8,6 +8,6 @@ function domain_source_test_domain_source_alter(&$source, $path, $options) {
   var_dump($path);
   $parts = explode('/', $path);
   if (isset($parts[1]) && $parts[1] == 'domain-format-test') {
-    $source = \Drupal::service('entity_type.manager')->getStorage('domain')->loadDefaultDomain();
+    $source = \Drupal::entityTypeManager()->getStorage('domain')->loadDefaultDomain();
   }
 }

--- a/domain_source/tests/src/Functional/DomainSourceElementTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceElementTest.php
@@ -67,7 +67,7 @@ class DomainSourceElementTest extends DomainTestBase {
     $this->fillField('title[0][value]', 'Test node');
 
     // We expect to find 5 domain options. We set two as selected.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $count = 0;
     $ids = ['example_com', 'one_example_com', 'two_example_com'];
     foreach ($domains as $domain) {

--- a/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
@@ -76,7 +76,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     $this->assertText('Domain Source', 'Found the domain field instance.');
 
     // We expect to find 5 domain options + none.
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
       $this->assertRaw($string, 'Found the domain option.');

--- a/domain_source/tests/src/Functional/DomainSourceExcludeTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceExcludeTest.php
@@ -45,7 +45,7 @@ class DomainSourceExcludeTest extends DomainTestBase {
 
     // Variables for our tests.
     $path = 'node/1';
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $source = $domains[$id];
     $expected = $source->getPath() . $path;
     $route_name = 'entity.node.canonical';

--- a/domain_source/tests/src/Functional/DomainSourceLanguageTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceLanguageTest.php
@@ -73,7 +73,7 @@ class DomainSourceLanguageTest extends DomainTestBase {
 
     // Variables for our tests.
     $path = 'node/1';
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $source = $domains[$id];
     $expected = $source->getPath() . $path;
     $route_name = 'entity.node.canonical';

--- a/domain_source/tests/src/Functional/DomainSourceParameterTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceParameterTest.php
@@ -38,7 +38,7 @@ class DomainSourceParameterTest extends DomainTestBase {
     // Variables for our tests.
     $path = 'domain-format-test';
     $options = ['query' => ['_format' => 'json']];
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $this->drupalGet($domain->getPath() . $path, $options);
     }

--- a/domain_source/tests/src/Functional/DomainSourceTrustedHostTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceTrustedHostTest.php
@@ -45,7 +45,7 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
 
     // Variables for our tests.
     $path = 'node/1';
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $source = $domains[$id];
     $expected = $source->getPath() . $path;
     $route_name = 'entity.node.canonical';

--- a/domain_source/tests/src/Functional/DomainSourceUrlTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceUrlTest.php
@@ -45,7 +45,7 @@ class DomainSourceUrlTest extends DomainTestBase {
 
     // Variables for our tests.
     $path = 'node/1';
-    $domains = \Drupal::service('entity_type.manager')->getStorage('domain')->loadMultiple();
+    $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     $source = $domains[$id];
     $expected = $source->getPath() . $path;
     $route_name = 'entity.node.canonical';


### PR DESCRIPTION
Easy to do so I've done it, but don't mind if it's deferred/postponed in favour of other things.