### PR TITLE
Remove an error inside DomainAliasLoaderInterface

### DIFF
--- a/domain_alias/src/DomainAliasLoaderInterface.php
+++ b/domain_alias/src/DomainAliasLoaderInterface.php
@@ -36,7 +36,7 @@ interface DomainAliasLoaderInterface {
    * @return array
    *   An array of Drupal\domain_alias\DomainAliasInterface objects.
    */
-  public function loadMultiple(array $ids = NULL, $reset = FALSE);
+  public function loadMultiple($ids = NULL, $reset = FALSE);
 
   /**
    * Loads a domain alias record by hostname lookup.


### PR DESCRIPTION
Remove an error  into DomainAliasLoaderInterface:

`Fatal error: Declaration of Drupal\domain_alias\DomainAliasLoader::loadMultiple($ids = NULL, $reset = false) must be compatible with Drupal\domain_alias\DomainAliasLoaderInterface::loadMultiple(array $ids = NULL, $reset = false) in /var/www/dev91/web/modules/contrib/domain/domain_alias/src/DomainAliasLoader.php on line 14`