### PR TITLE
Add domain_assets.module

### DIFF
--- a/domain_assets/domain_assets.info.yml
+++ b/domain_assets/domain_assets.info.yml
@@ -1,0 +1,8 @@
+name: Domain Assets
+description: 'Allows domain specific assets, e.g. for color.module.'
+type: module
+package: Domain
+version: VERSION
+core: 8.x
+dependencies:
+  - domain:domain

--- a/domain_assets/domain_assets.module
+++ b/domain_assets/domain_assets.module
@@ -19,7 +19,7 @@ function domain_assets_library_info_build() {
   /** @var \Drupal\domain\DomainInterface $domain */
   foreach (Domain::loadMultiple() as $domain) {
     $id = $domain->id();
-    $libraries["domain.dummy-$id"] = [];
+    $libraries["domain/dummy.$id"] = [];
   }
   return $libraries;
 }
@@ -45,5 +45,5 @@ function domain_assets_page_attachments(array &$attachments) {
   $negotiator = \Drupal::service('domain.negotiator');
   $domain = $negotiator->getActiveDomain();
   $id = $domain->id();
-  $attachments['#attached']['library'][] = "domain.dummy-$id";
+  $attachments['#attached']['library'][] = "domain/dummy.$id";
 }

--- a/domain_assets/domain_assets.module
+++ b/domain_assets/domain_assets.module
@@ -8,20 +8,17 @@
 use Drupal\domain\Entity\Domain;
 
 /**
- * Implements hook_library_info_build().
- *
- * Adds empty dummy libraries, one per domain.
- *
- * @aee domain_config_page_attachments().
+ * Implements hook_library_info_alter().
  */
-function domain_assets_library_info_build() {
-  $libraries = [];
+function domain_assets_library_info_alter(&$libraries, $extension) {
+  if ($extension !== 'domain_assets') {
+    return;
+  }
   /** @var \Drupal\domain\DomainInterface $domain */
   foreach (Domain::loadMultiple() as $domain) {
     $id = $domain->id();
-    $libraries["domain/dummy.$id"] = [];
+    $libraries["dummy.$id"] = ['css' => []];
   }
-  return $libraries;
 }
 
 /**

--- a/domain_assets/domain_assets.module
+++ b/domain_assets/domain_assets.module
@@ -19,6 +19,7 @@ function domain_assets_library_info_alter(&$libraries, $extension) {
     $id = $domain->id();
     $libraries["dummy.$id"] = ['css' => []];
   }
+  $libraries["dummy._none"] = ['css' => []];
 }
 
 /**
@@ -41,6 +42,6 @@ function domain_assets_page_attachments(array &$attachments) {
   /** @var \Drupal\domain\DomainNegotiatorInterface $negotiator */
   $negotiator = \Drupal::service('domain.negotiator');
   $domain = $negotiator->getActiveDomain();
-  $id = $domain->id();
+  $id = $domain ? $domain->id() : '_none';
   $attachments['#attached']['library'][] = "domain/dummy.$id";
 }

--- a/domain_assets/domain_assets.module
+++ b/domain_assets/domain_assets.module
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * Allows domain specific assets.
+ */
+
+use Drupal\domain\Entity\Domain;
+
+/**
+ * Implements hook_library_info_build().
+ *
+ * Adds empty dummy libraries, one per domain.
+ *
+ * @aee domain_config_page_attachments().
+ */
+function domain_assets_library_info_build() {
+  $libraries = [];
+  /** @var \Drupal\domain\DomainInterface $domain */
+  foreach (Domain::loadMultiple() as $domain) {
+    $id = $domain->id();
+    $libraries["domain.dummy-$id"] = [];
+  }
+  return $libraries;
+}
+
+/**
+ * Implements hook_page_attachments().
+ *
+ * Adds our domain specific dummy library to every page, as a hack to have
+ * AssetResolver cache asset info per domain. As AssetResolver caches asset
+ * info per hash-of-all-library-keys, with our dummy library we ensure that
+ * that cache key varies per domain. So if then e.g. color.module alters the
+ * theme css library info dependent on a domain dependent config, with our hack
+ * we avoid cache clashes.
+ * In an ideal world, the color module would propagete the cache context from
+ * config to library asset info to said cache key, but as there are currently
+ * no APIs for that, we simply do this and cache per domain.
+ *
+ * @see \Drupal\Core\Asset\AssetResolver::getCssAssets
+ * @see \Drupal\Core\Asset\AssetResolver::getJsAssets
+ */
+function domain_assets_page_attachments(array &$attachments) {
+  /** @var \Drupal\domain\DomainNegotiatorInterface $negotiator */
+  $negotiator = \Drupal::service('domain.negotiator');
+  $domain = $negotiator->getActiveDomain();
+  $id = $domain->id();
+  $attachments['#attached']['library'][] = "domain.dummy-$id";
+}

--- a/domain_assets/domain_assets.module
+++ b/domain_assets/domain_assets.module
@@ -43,5 +43,5 @@ function domain_assets_page_attachments(array &$attachments) {
   $negotiator = \Drupal::service('domain.negotiator');
   $domain = $negotiator->getActiveDomain();
   $id = $domain ? $domain->id() : '_none';
-  $attachments['#attached']['library'][] = "domain/dummy.$id";
+  $attachments['#attached']['library'][] = "domain_assets/dummy.$id";
 }


### PR DESCRIPTION
This module varies library info per domain, effectively allowing color settings per domain.

Also needed: Core patch [Color css files are not regenerated when deploying through configuration management \[\#2995825\] \| Drupal\.org](https://www.drupal.org/project/drupal/issues/2995825#comment-12832872) which might love some test fixes and RTBC.