### PR TITLE
[Test-only] domain_alias install fails with existing content

### DIFF
--- a/domain_alias/tests/src/Functional/DomainAliasInstall.php
+++ b/domain_alias/tests/src/Functional/DomainAliasInstall.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\domain_alias\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ *
+ *
+ * @group domain_alias
+ */
+class DomainAliasInstall extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['domain'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+  }
+
+  public function testInstallationNoContentPass() {
+    \Drupal::service('module_installer')->install(['domain_alias']);
+  }
+
+  public function testInstallationContentFail() {
+    $this->createContentType();
+    $this->createNode();
+    \Drupal::service('module_installer')->install(['domain_alias']);
+  }
+
+}
+


### PR DESCRIPTION
Built a test to demonstrate the failure of `domain_alias` module being installed after a site has content.

I realize the suggestion is present this is a stubborn Drupal cache, but it seems there should be _something_ we could do to help alleviate this issue?

Test for: https://www.drupal.org/project/domain/issues/2976117