### PR TITLE
Revert required context.

### DIFF
--- a/domain/src/Plugin/Condition/Domain.php
+++ b/domain/src/Plugin/Condition/Domain.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "domain",
  *   label = @Translation("Domain"),
  *   context = {
- *     "entity:domain" = @ContextDefinition("entity:domain", label = @Translation("Domain"), required = TRUE)
+ *     "entity:domain" = @ContextDefinition("entity:domain", label = @Translation("Domain"), required = FALSE)
  *   }
  * )
  */


### PR DESCRIPTION
This is a suggested revert of b375017ae131db1d638f3a19e5a82371ed22012a.

I am trying to upgrade domain from `alpha13` to `alpha14` and was previously using the domain condition in `page_manager` to select different homepage variants per webpage. It seems when this value changed from FALSE to TRUE, the ability to use Domain within page_manager was removed.

I couldn't find any background other than the commit message on why this was removed, so I was hoping to post this suggestion and see if I could get any more background here? Maybe we could fix this some other way?

_Edit:_ Closes #457