### PR TITLE
Failing test for invalid hook cache.

### DIFF
--- a/domain_config/tests/modules/domain_config_hook_test/domain_config_hook_test.info.yml
+++ b/domain_config/tests/modules/domain_config_hook_test/domain_config_hook_test.info.yml
@@ -1,0 +1,18 @@
+name: "Domain config hook test"
+description: "Support module for domain config testing."
+type: module
+package: Testing
+# version: VERSION
+core: 8.x
+hidden: TRUE
+
+dependencies: []
+
+# This module represents several services that could be provided by multiple modules in the Drupal community.
+# The following are not playing nice together:
+#   - A page cache policy service that uses the config factory.
+#   - A module that implements hook_module_implements.
+#   - A random hook that hook_module_implements wishes to control.
+#   - The domain_config module (and domain negotiator service, I believe).
+
+# When this module is functioning correctly, when a user logs in, there will not be a state key set.

--- a/domain_config/tests/modules/domain_config_hook_test/domain_config_hook_test.module
+++ b/domain_config/tests/modules/domain_config_hook_test/domain_config_hook_test.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for this module.
+ */
+
+/**
+ * Implements hook_user_login().
+ */
+function domain_config_hook_test_user_login($account) {
+  \Drupal::state()->set('domain_config_test__user_login', TRUE);
+}
+
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function domain_config_hook_test_module_implements_alter(&$implementations, $hook) {
+  if ($hook == 'user_login') {
+    // Turn off the domain_config_hook_test's hook_user_login (above).
+    unset($implementations['domain_config_hook_test']);
+  }
+}

--- a/domain_config/tests/modules/domain_config_hook_test/domain_config_hook_test.services.yml
+++ b/domain_config/tests/modules/domain_config_hook_test/domain_config_hook_test.services.yml
@@ -1,0 +1,7 @@
+services:
+  domain_config_service.page_cache_request_policy:
+    class: Drupal\domain_config_hook_test\PageCache\RequestPolicy\PageCacheRequestPolicy
+    arguments: ['@config.factory']
+    tags:
+      - { name: page_cache_request_policy }
+

--- a/domain_config/tests/modules/domain_config_hook_test/src/PageCache/RequestPolicy/PageCacheRequestPolicy.php
+++ b/domain_config/tests/modules/domain_config_hook_test/src/PageCache/RequestPolicy/PageCacheRequestPolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\domain_config_hook_test\PageCache\RequestPolicy;
+
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\PageCache\RequestPolicyInterface;
+use Drupal\Core\Session\SessionConfigurationInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * A page cache request policy.
+ *
+ * This service is not meant to DO anything, it's just meant to represent
+ * a service that might be present in the Drupal community. For example,
+ * persistent_login module has this same structure.
+ */
+class PageCacheRequestPolicy implements RequestPolicyInterface {
+
+  /**
+   * Drupal config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   Drupal config factory.
+   */
+  public function __construct(ConfigFactory $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function check(Request $request) {
+    // This line is important. You have to use this service for it to fail.
+    $this->configFactory
+      ->get('system.site');
+
+    return NULL;
+  }
+
+}

--- a/domain_config/tests/src/Functional/DomainConfigHookProblemTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHookProblemTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\Tests\domain_config\Functional;
+
+/**
+ * Tests the domain config system.
+ *
+ * @group domain_config
+ */
+class DomainConfigHookProblemTest extends DomainConfigHookTest {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    // Adds the domain_config module.
+    'domain_config',
+  ];
+
+  /**
+   * Disabled config schema checking.
+   *
+   * Domain Config actually duplicates schemas provided by other modules,
+   * so it cannot define its own.
+   *
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+}

--- a/domain_config/tests/src/Functional/DomainConfigHookTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHookTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\Tests\domain_config\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the domain config system.
+ *
+ * @group domain_config
+ */
+class DomainConfigHookTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'domain',
+    // See module info file for description of what this module does.
+    'domain_config_hook_test',
+  ];
+
+  /**
+   * Test to ensure a domain_config_hook_test_user_login() does not run.
+   *
+   * This test serves as a control to show the domain_config_hook_test module
+   * functions correctly on it's own. Only when you add the domain_config
+   * module, does it fail.
+   */
+  public function testHookRuns() {
+    $this->drupalGet('user/login');
+    $user = $this->drupalCreateUser([]);
+    $edit = ['name' => $user->getUserName(), 'pass' => $user->passRaw];
+    $this->drupalPostForm(NULL, $edit, t('Log in'));
+
+    $test = \Drupal::state()->get('domain_config_test__user_login', NULL);
+    // When this test passes, it means domain_config_hook_test_user_login was
+    // not run.
+    $this->assertNull($test, 'The hook_user_login state message is set.');
+  }
+
+}


### PR DESCRIPTION
Test to demonstrate issue in https://www.drupal.org/project/domain/issues/3025541

I found there's a problem using domain_config (which injects DomainNegotiator service, which invokes hooks) along with a service that runs early in the drupal bootstrap process, such as a page cache policy service.

I have added two unit tests here. One that runs and operates as expected, and then the same test that fails once `domain_config` gets installed.