### PR TITLE
Add option to domain source to stop redirection from aliases

### DIFF
--- a/domain_source/config/install/domain_source.settings.yml
+++ b/domain_source/config/install/domain_source.settings.yml
@@ -1,1 +1,2 @@
 exclude_routes: {}
+dont_redirect_on_aliases: 0

--- a/domain_source/config/schema/domain_source.schema.yml
+++ b/domain_source/config/schema/domain_source.schema.yml
@@ -8,3 +8,6 @@ domain_source.settings:
       sequence:
         type: string
         label: 'Route'
+    dont_redirect_on_aliases:
+      type: boolean
+      label: 'Stop redirecting on aliases'

--- a/domain_source/src/Form/DomainSourceSettingsForm.php
+++ b/domain_source/src/Form/DomainSourceSettingsForm.php
@@ -49,6 +49,11 @@ class DomainSourceSettingsForm extends ConfigFormBase {
       '#options' => $options,
       '#description' => $this->t('Check the routes to disable. Any entity URL with a Domain Source field will be rewritten unless its corresponding route is disabled.'),
     ];
+    $form['dont_redirect_on_aliases'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Don\'t redirect to the primary domain on aliases'),
+      '#default_value' => $config->get('dont_redirect_on_aliases')
+    ];
     return parent::buildForm($form, $form_state);
   }
 
@@ -58,6 +63,7 @@ class DomainSourceSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config('domain_source.settings')
       ->set('exclude_routes', $form_state->getValue('exclude_routes'))
+      ->set('dont_redirect_on_aliases', $form_state->getValue('dont_redirect_on_aliases'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/domain_source/src/HttpKernel/DomainSourcePathProcessor.php
+++ b/domain_source/src/HttpKernel/DomainSourcePathProcessor.php
@@ -106,6 +106,8 @@ class DomainSourcePathProcessor implements OutboundPathProcessorInterface {
    * {@inheritdoc}
    */
   public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    $config = $this->configFactory->get('domain_source.settings');
+
     // Load the active domain if not set.
     if (empty($options['active_domain'])) {
       $active_domain = $this->getActiveDomain();
@@ -173,7 +175,7 @@ class DomainSourcePathProcessor implements OutboundPathProcessorInterface {
       $this->moduleHandler->alter('domain_source_path', $source, $path, $options);
     }
     // If a source domain is specified, rewrite the link.
-    if (!empty($source)) {
+    if (!empty($source) && (!$config->get('dont_redirect_on_aliases') || ($config->get('dont_redirect_on_aliases') && $source->id() != $options['active_domain']->id()))) {
       // Note that url rewrites add a leading /, which getPath() also adds.
       $options['base_url'] = trim($source->getPath(), '/');
       $options['absolute'] = TRUE;


### PR DESCRIPTION
The current default behaviour of Domain source is to direct to the primary domain even if you are on an alias of the current domain that needs to be redirected to.

This caused me huge problems with GraphQL doing a route lookup query

```
query {
  route(path: "/bar") {
    ... on InternalUrl {
      nodeContext {
        __typename
      }
    }
  }
}
```

So in the example of using a primary domain of `foo.com` and the a graphql domain of `api.foo.com` and the Domain source it will try to redirect.
