### PR TITLE
Replace deprecations in tests

### DIFF
--- a/domain/tests/src/Functional/Condition/DomainConditionTest.php
+++ b/domain/tests/src/Functional/Condition/DomainConditionTest.php
@@ -79,11 +79,11 @@ class DomainConditionTest extends DomainTestBase {
 
     // Check for the proper summary.
     // Summaries require an extra space due to negate handling in summary().
-    $this->assertEqual($condition->summary(), 'Active domain is ' . $this->testDomain->label());
+    $this->assertEquals($condition->summary(), 'Active domain is ' . $this->testDomain->label());
 
     // Check the negated summary.
     $condition->setConfig('negate', TRUE);
-    $this->assertEqual($condition->summary(), 'Active domain is not ' . $this->testDomain->label());
+    $this->assertEquals($condition->summary(), 'Active domain is not ' . $this->testDomain->label());
 
     // Check the negated condition.
     $this->assertFalse($condition->execute(), 'Domain request condition fails when condition negated.');

--- a/domain/tests/src/Functional/Condition/DomainConditionTest.php
+++ b/domain/tests/src/Functional/Condition/DomainConditionTest.php
@@ -42,7 +42,7 @@ class DomainConditionTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Set the condition manager.

--- a/domain/tests/src/Functional/DomainActionsTest.php
+++ b/domain/tests/src/Functional/DomainActionsTest.php
@@ -23,7 +23,7 @@ class DomainActionsTest extends DomainTestBase {
 
     // Visit the domain overview administration page.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Test the domains.
     $storage = \Drupal::entityTypeManager()->getStorage('domain');
@@ -33,28 +33,28 @@ class DomainActionsTest extends DomainTestBase {
     // Check the default domain.
     $default = $storage->loadDefaultId();
     $key = 'example_com';
-    $this->assertTrue($default == $key, 'Default domain set correctly.');
+    $this->assertEquals($default, $key, 'Default domain set correctly.');
 
     // Test some text on the page.
     foreach ($domains as $domain) {
       $name = $domain->label();
-      $this->assertText($name, 'Name found properly.');
+      $this->assertSession()->pageTextContains($name);
     }
     // Test the list of actions.
     $actions = ['delete', 'disable', 'default'];
     foreach ($actions as $action) {
-      $this->assertRaw("/domain/{$action}/", 'Actions found properly.');
+      $this->assertSession()->responseContains("/domain/{$action}/");
     }
     // Check that all domains are active.
-    $this->assertNoRaw('Inactive', 'Inactive domain not found.');
+    $this->assertSession()->responseNotContains('Inactive');
 
     // Disable a domain and test the enable link.
     $this->clickLink('Disable', 0);
-    $this->assertRaw('Inactive', 'Inactive domain found.');
+    $this->assertSession()->responseContains('Inactive');
 
     // Visit the domain overview administration page to clear cache.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     foreach ($storage->loadMultiple() as $domain) {
       if ($domain->id() == 'one_example_com') {
@@ -68,15 +68,15 @@ class DomainActionsTest extends DomainTestBase {
     // Test the list of actions.
     $actions = ['enable', 'delete', 'disable', 'default'];
     foreach ($actions as $action) {
-      $this->assertRaw("/domain/{$action}/", 'Actions found properly.');
+      $this->assertSession()->responseContains("/domain/{$action}/");
     }
     // Re-enable the domain.
     $this->clickLink('Enable', 0);
-    $this->assertNoRaw('Inactive', 'Inactive domain not found.');
+    $this->assertSession()->responseNotContains('Inactive');
 
     // Visit the domain overview administration page to clear cache.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     foreach ($storage->loadMultiple() as $domain) {
       $this->assertNotEmpty($domain->status(), 'All domains active.');
@@ -87,13 +87,13 @@ class DomainActionsTest extends DomainTestBase {
 
     // Visit the domain overview administration page to clear cache.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the default domain.
     $storage->resetCache();
     $default = $storage->loadDefaultId();
     $key = 'one_example_com';
-    $this->assertTrue($default == $key, 'Default domain set correctly.');
+    $this->assertEquals($default, $key, 'Default domain set correctly.');
 
   }
 

--- a/domain/tests/src/Functional/DomainAdminElementTest.php
+++ b/domain/tests/src/Functional/DomainAdminElementTest.php
@@ -16,12 +16,12 @@ class DomainAdminElementTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'field', 'field_ui', 'user'];
+  protected static $modules = ['domain', 'field', 'field_ui', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain/tests/src/Functional/DomainAdminElementTest.php
+++ b/domain/tests/src/Functional/DomainAdminElementTest.php
@@ -70,7 +70,7 @@ class DomainAdminElementTest extends DomainTestBase {
     // Check that two values are set.
     $manager = \Drupal::service('domain.element_manager');
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 3, 'User saved with three domain records.');
+    $this->assertCount(3, $values, 'User saved with three domain records.');
 
     // Now login as a user with limited rights.
     $account = $this->drupalCreateUser([
@@ -81,7 +81,7 @@ class DomainAdminElementTest extends DomainTestBase {
     $this->addDomainsToEntity('user', $account->id(), $ids, DOMAIN_ADMIN_FIELD);
     $tester = $storage->load($account->id());
     $values = $manager->getFieldValues($tester, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $this->assertCount(2, $values, 'User saved with two domain records.');
     $storage->resetCache([$account->id()]);
     $this->drupalLogin($account);
 
@@ -111,7 +111,7 @@ class DomainAdminElementTest extends DomainTestBase {
     $user = $storage->load($user->id());
     // Check that two values are set.
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $this->assertCount(2, $values, 'User saved with two domain records.');
 
     // Test the case presented in https://www.drupal.org/node/2841962.
     $config = \Drupal::configFactory()->getEditable('user.settings');

--- a/domain/tests/src/Functional/DomainCSSTest.php
+++ b/domain/tests/src/Functional/DomainCSSTest.php
@@ -16,12 +16,12 @@ class DomainCSSTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain'];
+  protected static $modules = ['domain'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     \Drupal::service('theme_installer')->install(['bartik']);
   }
@@ -45,7 +45,7 @@ class DomainCSSTest extends DomainTestBase {
     foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
       $text = '<body class="' . Html::getClass($domain->id() . '-class');
-      $this->assertSession()->responseNotContains($text, 'No custom CSS present.');
+      $this->assertSession()->responseNotContains($text);
     }
     // Set the css classes.
     $config = $this->config('domain.settings');

--- a/domain/tests/src/Functional/DomainCSSTest.php
+++ b/domain/tests/src/Functional/DomainCSSTest.php
@@ -45,7 +45,7 @@ class DomainCSSTest extends DomainTestBase {
     foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
       $text = '<body class="' . Html::getClass($domain->id() . '-class');
-      $this->assertNoRaw($text, 'No custom CSS present.');
+      $this->assertSession()->responseNotContains($text, 'No custom CSS present.');
     }
     // Set the css classes.
     $config = $this->config('domain.settings');
@@ -58,7 +58,7 @@ class DomainCSSTest extends DomainTestBase {
       drupal_flush_all_caches();
       $this->drupalGet($domain->getPath());
       $text = '<body class="' . Html::getClass($domain->id() . '-class');
-      $this->assertRaw($text, 'Custom CSS present.' . $text);
+      $this->assertSession()->responseContains($text);
     }
 
     // Set the css classes.
@@ -71,7 +71,7 @@ class DomainCSSTest extends DomainTestBase {
       drupal_flush_all_caches();
       $this->drupalGet($domain->getPath());
       $text = '<body class="' . Html::getClass($domain->id() . '-class') . ' ' . Html::getClass($domain->label() . '-class');
-      $this->assertRaw($text, 'Custom CSS present.' . $text);
+      $this->assertSession()->responseContains($text);
     }
 
   }

--- a/domain/tests/src/Functional/DomainCheckResponseTest.php
+++ b/domain/tests/src/Functional/DomainCheckResponseTest.php
@@ -22,7 +22,8 @@ class DomainCheckResponseTest extends DomainTestBase {
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'example.com';
-    $this->submitForm('admin/config/domain/add', $edit, 'Save');
+    $this->drupalGet('admin/config/domain/add');
+    $this->submitForm($edit, 'Save');
 
     // Did it save correctly?
     $this->assertSession()->responseNotContains('The server request to');
@@ -36,7 +37,8 @@ class DomainCheckResponseTest extends DomainTestBase {
     $edit['id'] = $storage->createMachineName($edit['hostname']);
     $edit['validate_url'] = 1;
     try {
-      $this->submitForm('admin/config/domain/add', $edit, 'Save');
+      $this->drupalGet('admin/config/domain/add');
+      $this->submitForm($edit, 'Save');
     }
     catch (\Exception $e) {
       // Ensure no test errors.
@@ -48,7 +50,8 @@ class DomainCheckResponseTest extends DomainTestBase {
 
     // Bypass the check.
     $edit['validate_url'] = 0;
-    $this->submitForm('admin/config/domain/add', $edit, 'Save');
+    $this->drupalGet('admin/config/domain/add');
+    $this->submitForm($edit, 'Save');
 
     // The domain should save.
     $this->assertSession()->responseNotContains('The server request to');

--- a/domain/tests/src/Functional/DomainCheckResponseTest.php
+++ b/domain/tests/src/Functional/DomainCheckResponseTest.php
@@ -22,10 +22,10 @@ class DomainCheckResponseTest extends DomainTestBase {
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'example.com';
-    $this->drupalPostForm('admin/config/domain/add', $edit, 'Save');
+    $this->submitForm('admin/config/domain/add', $edit, 'Save');
 
     // Did it save correctly?
-    $this->assertNoRaw('The server request to');
+    $this->assertSession()->responseNotContains('The server request to');
     $domains = $storage->loadMultiple();
     $this->assertCount(1, $domains, 'Domain record saved via form.');
 
@@ -36,22 +36,22 @@ class DomainCheckResponseTest extends DomainTestBase {
     $edit['id'] = $storage->createMachineName($edit['hostname']);
     $edit['validate_url'] = 1;
     try {
-      $this->drupalPostForm('admin/config/domain/add', $edit, 'Save');
+      $this->submitForm('admin/config/domain/add', $edit, 'Save');
     }
     catch (\Exception $e) {
       // Ensure no test errors.
     }
     // The domain should not save.
-    $this->assertRaw('The server request to');
+    $this->assertSession()->responseContains('The server request to');
     $domains = $storage->loadMultiple();
     $this->assertCount(1, $domains, 'Domain record not saved via form.');
 
     // Bypass the check.
     $edit['validate_url'] = 0;
-    $this->drupalPostForm('admin/config/domain/add', $edit, 'Save');
+    $this->submitForm('admin/config/domain/add', $edit, 'Save');
 
     // The domain should save.
-    $this->assertNoRaw('The server request to');
+    $this->assertSession()->responseNotContains('The server request to');
     $domains = $storage->loadMultiple();
     $this->assertCount(2, $domains, 'Domain record saved via form.');
   }

--- a/domain/tests/src/Functional/DomainEntityAccessTest.php
+++ b/domain/tests/src/Functional/DomainEntityAccessTest.php
@@ -38,7 +38,7 @@ class DomainEntityAccessTest extends DomainTestBase {
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'example.com';
-    $this->drupalPostForm('admin/config/domain/add', $edit, 'Save');
+    $this->submitForm('admin/config/domain/add', $edit, 'Save');
 
     // Did it save correctly?
     $default_id = $storage->loadDefaultId();
@@ -59,13 +59,13 @@ class DomainEntityAccessTest extends DomainTestBase {
 
     // Visit the add domain add page.
     $this->drupalGet('admin/config/domain/add');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     // Make a POST request on admin/config/domain/add.
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'one.example.com';
     $edit['id'] = \Drupal::entityTypeManager()->getStorage('domain')->createMachineName($edit['hostname']);
-    $this->drupalPostForm('admin/config/domain/add', $edit, 'Save');
+    $this->submitForm('admin/config/domain/add', $edit, 'Save');
 
     // Does it load correctly?
     $storage->resetCache([$edit['id']]);
@@ -79,7 +79,7 @@ class DomainEntityAccessTest extends DomainTestBase {
     $this->drupalLogin($noneditor);
     // Visit the add domain administration page.
     $this->drupalGet('admin/config/domain/add');
-    $this->assertResponse(403);
+    $this->assertSession()->statusCodeEquals(403);
   }
 
 }

--- a/domain/tests/src/Functional/DomainEntityAccessTest.php
+++ b/domain/tests/src/Functional/DomainEntityAccessTest.php
@@ -29,7 +29,7 @@ class DomainEntityAccessTest extends DomainTestBase {
     $this->drupalGet('admin/config/domain');
 
     // Check for the add message.
-    $this->assertText('There are no domain record entities yet.', 'Text for no domains found.');
+    $this->assertSession()->pageTextContains('There are no domain record entities yet.');
 
     // Visit the add domain administration page.
     $this->drupalGet('admin/config/domain/add');

--- a/domain/tests/src/Functional/DomainEntityAccessTest.php
+++ b/domain/tests/src/Functional/DomainEntityAccessTest.php
@@ -38,7 +38,8 @@ class DomainEntityAccessTest extends DomainTestBase {
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'example.com';
-    $this->submitForm('admin/config/domain/add', $edit, 'Save');
+    $this->drupalGet('admin/config/domain/add');
+    $this->submitForm($edit, 'Save');
 
     // Did it save correctly?
     $default_id = $storage->loadDefaultId();
@@ -47,7 +48,7 @@ class DomainEntityAccessTest extends DomainTestBase {
     // Does it load correctly?
     $storage->resetCache([$default_id]);
     $new_domain = $storage->load($default_id);
-    $this->assertTrue($new_domain->id() == $default_id, 'Domain loaded properly.');
+    $this->assertEquals($default_id, $new_domain->id(), 'Domain loaded properly.');
 
     $this->drupalLogout();
     $editor = $this->drupalCreateUser([
@@ -65,12 +66,14 @@ class DomainEntityAccessTest extends DomainTestBase {
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'one.example.com';
     $edit['id'] = \Drupal::entityTypeManager()->getStorage('domain')->createMachineName($edit['hostname']);
-    $this->submitForm('admin/config/domain/add', $edit, 'Save');
+    $this->drupalGet('admin/config/domain/add');
+    $this->submitForm($edit, 'Save');
+
 
     // Does it load correctly?
     $storage->resetCache([$edit['id']]);
     $new_domain = $storage->load($edit['id']);
-    $this->assertTrue($new_domain->id() == $edit['id'], 'Domain loaded properly.');
+    $this->assertEquals($edit['id'], $new_domain->id(), 'Domain loaded properly.');
 
     $this->drupalLogout();
     $noneditor = $this->drupalCreateUser([

--- a/domain/tests/src/Functional/DomainEntityReferenceTest.php
+++ b/domain/tests/src/Functional/DomainEntityReferenceTest.php
@@ -14,7 +14,7 @@ class DomainEntityReferenceTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'field', 'field_ui'];
+  protected static $modules = ['domain', 'field', 'field_ui'];
 
   /**
    * Create, edit and delete a domain field via the user interface.

--- a/domain/tests/src/Functional/DomainEntityReferenceTest.php
+++ b/domain/tests/src/Functional/DomainEntityReferenceTest.php
@@ -30,17 +30,17 @@ class DomainEntityReferenceTest extends DomainTestBase {
 
     // Visit the article field administration page.
     $this->drupalGet('admin/structure/types/manage/article/fields');
-    $this->assertResponse(200, 'Manage fields page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertNoText('Domain test field', 'Domain form field not found.');
+    $this->assertNoText('Domain test field');
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
-    $this->assertResponse(200, 'Manage field display page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertNoText('Domain test field', 'Domain form field not found.');
+    $this->assertNoText('Domain test field');
 
     // Create test domain field.
     $this->domainCreateTestField();
@@ -49,13 +49,13 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $this->drupalGet('admin/structure/types/manage/article/fields');
 
     // Check the new field.
-    $this->assertText('Domain test field', 'Added a test field instance.');
+    $this->assertText('Domain test field');
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
 
     // Check the new field.
-    $this->assertText('Domain test field', 'Added a test field display instance.');
+    $this->assertText('Domain test field');
   }
 
   /**
@@ -79,16 +79,16 @@ class DomainEntityReferenceTest extends DomainTestBase {
 
     // Visit the article field display administration page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the new field exists on the page.
-    $this->assertText('Domain test field', 'Found the domain field instance.');
+    $this->assertText('Domain test field');
 
     // We expect to find 5 domain options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
-      $this->assertRaw($string, 'Found the domain option');
+      $this->assertSession()->responseContains($string);
       if (!isset($one)) {
         $one = $domain->id();
         continue;
@@ -102,8 +102,8 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $edit['title[0][value]'] = 'Test node';
     $edit["field_domain[{$one}]"] = TRUE;
     $edit["field_domain[{$two}]"] = TRUE;
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
-    $this->assertResponse(200);
+    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
     $values = $node->get('field_domain');
 

--- a/domain/tests/src/Functional/DomainEntityReferenceTest.php
+++ b/domain/tests/src/Functional/DomainEntityReferenceTest.php
@@ -33,14 +33,14 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertNoText('Domain test field');
+    $this->assertSession()->pageTextNotContains('Domain test field');
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
     $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertNoText('Domain test field');
+    $this->assertSession()->pageTextNotContains('Domain test field');
 
     // Create test domain field.
     $this->domainCreateTestField();
@@ -49,13 +49,13 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $this->drupalGet('admin/structure/types/manage/article/fields');
 
     // Check the new field.
-    $this->assertText('Domain test field');
+    $this->assertSession()->pageTextContains('Domain test field');
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
 
     // Check the new field.
-    $this->assertText('Domain test field');
+    $this->assertSession()->pageTextContains('Domain test field');
   }
 
   /**
@@ -82,7 +82,7 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Check the new field exists on the page.
-    $this->assertText('Domain test field');
+    $this->assertSession()->pageTextContains('Domain test field');
 
     // We expect to find 5 domain options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();

--- a/domain/tests/src/Functional/DomainEntityReferenceTest.php
+++ b/domain/tests/src/Functional/DomainEntityReferenceTest.php
@@ -102,7 +102,8 @@ class DomainEntityReferenceTest extends DomainTestBase {
     $edit['title[0][value]'] = 'Test node';
     $edit["field_domain[{$one}]"] = TRUE;
     $edit["field_domain[{$two}]"] = TRUE;
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->drupalGet('node/add/article');
+    $this->submitForm($edit, 'Save');
     $this->assertSession()->statusCodeEquals(200);
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
     $values = $node->get('field_domain');

--- a/domain/tests/src/Functional/DomainFormsTest.php
+++ b/domain/tests/src/Functional/DomainFormsTest.php
@@ -25,7 +25,7 @@ class DomainFormsTest extends DomainTestBase {
     $this->drupalGet('admin/config/domain');
 
     // Check for the add message.
-    $this->assertText('There are no domain record entities yet.', 'Text for no domains found.');
+    $this->assertSession()->pageTextContains('There are no domain record entities yet.');
 
     // Visit the add domain administration page.
     $this->drupalGet('admin/config/domain/add');

--- a/domain/tests/src/Functional/DomainFormsTest.php
+++ b/domain/tests/src/Functional/DomainFormsTest.php
@@ -69,7 +69,7 @@ class DomainFormsTest extends DomainTestBase {
     $this->drupalGet($deleteUrl);
 
     // Delete the record.
-    $this->submitForm([], 'Save');
+    $this->submitForm([], 'Delete');
     $storage->resetCache([$default_id]);
     $domain = $storage->load($default_id);
     $this->assertEmpty($domain, 'Domain record deleted.');

--- a/domain/tests/src/Functional/DomainFormsTest.php
+++ b/domain/tests/src/Functional/DomainFormsTest.php
@@ -34,7 +34,7 @@ class DomainFormsTest extends DomainTestBase {
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'example.com';
-    $this->submitForm('admin/config/domain/add', $edit, 'Save');
+    $this->submitForm($edit, 'Save');
 
     // Did it save correctly?
     $default_id = $storage->loadDefaultId();
@@ -43,7 +43,7 @@ class DomainFormsTest extends DomainTestBase {
     // Does it load correctly?
     $storage->resetCache([$default_id]);
     $new_domain = $storage->load($default_id);
-    $this->assertTrue($new_domain->id() == $default_id, 'Domain loaded properly.');
+    $this->assertEquals($default_id, $new_domain->id(), 'Domain loaded properly.');
 
     // Has a UUID been set?
     $this->assertNotEmpty($new_domain->uuid(), 'Entity UUID set properly.');
@@ -56,19 +56,20 @@ class DomainFormsTest extends DomainTestBase {
     $edit = [];
     $edit['name'] = 'Foo';
     $edit['validate_url'] = 0;
-    $this->submitForm($editUrl, $edit, 'Save');
+    $this->drupalGet($editUrl);
+    $this->submitForm($edit, 'Save');
 
     // Check that the update succeeded.
     $storage->resetCache([$default_id]);
     $domain = $storage->load($default_id);
-    $this->assertTrue($domain->label() == 'Foo', 'Domain record updated via form.');
+    $this->assertEquals('Foo', $domain->label(), 'Domain record updated via form.');
 
     // Visit the delete domain administration page.
     $deleteUrl = 'admin/config/domain/delete/' . $new_domain->id();
     $this->drupalGet($deleteUrl);
 
     // Delete the record.
-    $this->submitForm($deleteUrl, [], 'Delete');
+    $this->submitForm([], 'Save');
     $storage->resetCache([$default_id]);
     $domain = $storage->load($default_id);
     $this->assertEmpty($domain, 'Domain record deleted.');

--- a/domain/tests/src/Functional/DomainFormsTest.php
+++ b/domain/tests/src/Functional/DomainFormsTest.php
@@ -34,7 +34,7 @@ class DomainFormsTest extends DomainTestBase {
     $edit = $this->domainPostValues();
     // Use hostname with dot (.) to avoid validation error.
     $edit['hostname'] = 'example.com';
-    $this->drupalPostForm('admin/config/domain/add', $edit, 'Save');
+    $this->submitForm('admin/config/domain/add', $edit, 'Save');
 
     // Did it save correctly?
     $default_id = $storage->loadDefaultId();
@@ -56,7 +56,7 @@ class DomainFormsTest extends DomainTestBase {
     $edit = [];
     $edit['name'] = 'Foo';
     $edit['validate_url'] = 0;
-    $this->drupalPostForm($editUrl, $edit, 'Save');
+    $this->submitForm($editUrl, $edit, 'Save');
 
     // Check that the update succeeded.
     $storage->resetCache([$default_id]);
@@ -68,7 +68,7 @@ class DomainFormsTest extends DomainTestBase {
     $this->drupalGet($deleteUrl);
 
     // Delete the record.
-    $this->drupalPostForm($deleteUrl, [], 'Delete');
+    $this->submitForm($deleteUrl, [], 'Delete');
     $storage->resetCache([$default_id]);
     $domain = $storage->load($default_id);
     $this->assertEmpty($domain, 'Domain record deleted.');

--- a/domain/tests/src/Functional/DomainGetResponseTest.php
+++ b/domain/tests/src/Functional/DomainGetResponseTest.php
@@ -25,7 +25,7 @@ class DomainGetResponseTest extends DomainTestBase {
     $domain = \Drupal::entityTypeManager()->getStorage('domain')->load($key);
 
     // Our testing server should be able to access the test PNG file.
-    $this->assert($domain->getResponse() == 200, 'Server returned a 200 response.');
+    $this->assertEquals(200, $domain->getResponse(), 'Server returned a 200 response.');
 
     // Now create a bad domain.
     $values = [
@@ -36,7 +36,7 @@ class DomainGetResponseTest extends DomainTestBase {
     $domain = \Drupal::entityTypeManager()->getStorage('domain')->create($values);
 
     $domain->save();
-    $this->assert($domain->getResponse() == 500, 'Server test returned a 500 response.');
+    $this->assertEquals(500, $domain->getResponse(), 'Server test returned a 500 response.');
   }
 
 }

--- a/domain/tests/src/Functional/DomainInactiveTest.php
+++ b/domain/tests/src/Functional/DomainInactiveTest.php
@@ -17,7 +17,7 @@ class DomainInactiveTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'node', 'views'];
+  protected static $modules = ['domain', 'node', 'views'];
 
   /**
    * Test inactive domain.
@@ -82,7 +82,7 @@ class DomainInactiveTest extends DomainTestBase {
 
     // Test the trusted host, which should redirect to default.
     $this->drupalGet($domain->getPath());
-    $this->assertTrue($this->getUrl(), $domain2->getPath(), 'Redirected from the inactive domain.');
+    $this->assertEquals($this->getUrl(), $domain2->getPath(), 'Redirected from the inactive domain.');
     $this->assertSession()->statusCodeEquals(200);
 
     // The redirect is cached, so we must flush cache to test again.

--- a/domain/tests/src/Functional/DomainInactiveTest.php
+++ b/domain/tests/src/Functional/DomainInactiveTest.php
@@ -49,11 +49,11 @@ class DomainInactiveTest extends DomainTestBase {
     // Check to see if the user can login.
     $url = $domain->getPath() . 'user/login';
     $this->drupalGet($url);
-    $this->assertResponse(200, 'Request to login on inactive domain allowed.');
+    $this->assertSession()->statusCodeEquals(200);
     // Check to see if the user can reset password.
     $url = $domain->getPath() . 'user/password';
     $this->drupalGet($url);
-    $this->assertResponse(200, 'Request to reset password on inactive domain allowed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Try to access with the proper permission.
     user_role_grant_permissions(AccountInterface::ANONYMOUS_ROLE, ['access inactive domains']);
@@ -83,7 +83,7 @@ class DomainInactiveTest extends DomainTestBase {
     // Test the trusted host, which should redirect to default.
     $this->drupalGet($domain->getPath());
     $this->assertTrue($domain2->getPath() == $this->getUrl(), 'Redirected from the inactive domain.');
-    $this->assertResponse(200, 'Request to trusted host allowed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // The redirect is cached, so we must flush cache to test again.
     drupal_flush_all_caches();
@@ -92,7 +92,7 @@ class DomainInactiveTest extends DomainTestBase {
     // Disable the domain and test for redirect.
     $domain3->saveDefault();
     $this->drupalGet($domain->getPath());
-    $this->assertRaw('The provided host name is not a valid redirect.');
+    $this->assertSession()->responseContains('The provided host name is not a valid redirect.');
   }
 
 }

--- a/domain/tests/src/Functional/DomainInactiveTest.php
+++ b/domain/tests/src/Functional/DomainInactiveTest.php
@@ -35,7 +35,7 @@ class DomainInactiveTest extends DomainTestBase {
     $domain = $domains['two_example_com'];
     $this->drupalGet($domain->getPath());
     $this->assertTrue($domain->status(), 'Tested domain is set to active.');
-    $this->assertTrue($domain->getPath() == $this->getUrl(), 'Loaded the active domain.');
+    $this->assertEquals($this->getUrl(), $domain->getPath(), 'Loaded the active domain.');
 
     // Disable the domain and test for redirect.
     $domain->disable();
@@ -44,7 +44,7 @@ class DomainInactiveTest extends DomainTestBase {
     $this->drupalGet($domain->getPath());
 
     $this->assertFalse($domain->status(), 'Tested domain is set to inactive.');
-    $this->assertTrue($default->getPath() == $this->getUrl(), 'Redirected an inactive domain to the default domain.');
+    $this->assertEquals($this->getUrl(), $default->getPath(), 'Redirected an inactive domain to the default domain.');
 
     // Check to see if the user can login.
     $url = $domain->getPath() . 'user/login';
@@ -82,7 +82,7 @@ class DomainInactiveTest extends DomainTestBase {
 
     // Test the trusted host, which should redirect to default.
     $this->drupalGet($domain->getPath());
-    $this->assertTrue($domain2->getPath() == $this->getUrl(), 'Redirected from the inactive domain.');
+    $this->assertTrue($this->getUrl(), $domain2->getPath(), 'Redirected from the inactive domain.');
     $this->assertSession()->statusCodeEquals(200);
 
     // The redirect is cached, so we must flush cache to test again.

--- a/domain/tests/src/Functional/DomainListBuilderTest.php
+++ b/domain/tests/src/Functional/DomainListBuilderTest.php
@@ -14,12 +14,12 @@ class DomainListBuilderTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'user'];
+  protected static $modules = ['domain', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 150 domains.
@@ -204,7 +204,7 @@ class DomainListBuilderTest extends DomainTestBase {
    */
   private function checkNoPagination() {
     foreach (['?page=0', '?page=1', '?page=2'] as $href) {
-      $this->assertSession()->linkByHrefNotExists($href, 0, 'Link not found');
+      $this->assertSession()->linkByHrefNotExists($href, 'Link not found');
     }
   }
 

--- a/domain/tests/src/Functional/DomainListBuilderTest.php
+++ b/domain/tests/src/Functional/DomainListBuilderTest.php
@@ -74,7 +74,7 @@ class DomainListBuilderTest extends DomainTestBase {
     $user = $user_storage->load($account->id());
     $manager = \Drupal::service('domain.element_manager');
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $this->assertCount(2, $values, 'User saved with two domain records.');
 
     $this->drupalLogin($account);
 
@@ -140,7 +140,7 @@ class DomainListBuilderTest extends DomainTestBase {
     $user = $user_storage->load($account2->id());
     $manager = \Drupal::service('domain.element_manager');
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $this->assertCount(2, $values, 'User saved with two domain records.');
 
     $this->drupalLogin($account2);
 

--- a/domain/tests/src/Functional/DomainListWeightTest.php
+++ b/domain/tests/src/Functional/DomainListWeightTest.php
@@ -103,7 +103,7 @@ class DomainListWeightTest extends DomainTestBase {
       }
     }
     // The last domain should be test59_example_com.
-    $this->assert($domain->id() == 'test59_example_com', 'Last domain is test59' . $domain->id());
+    $this->assertEquals('test59_example_com', $domain->id(), 'Last domain is test59' . $domain->id());
   }
 
 }

--- a/domain/tests/src/Functional/DomainListWeightTest.php
+++ b/domain/tests/src/Functional/DomainListWeightTest.php
@@ -34,11 +34,11 @@ class DomainListWeightTest extends DomainTestBase {
     $domains = $this->getDomainsSorted();
     $i = 1;
     foreach ($domains as $domain) {
-      $this->assert($domain->getWeight() == $i, 'Weight set to ' . $i);
+      $this->assertEquals($i, $domain->getWeight(), 'Weight set to ' . $i);
       $i++;
     }
     // The last domain should be test59_example_com.
-    $this->assert($domain->id() == 'test59_example_com', 'Last domain is test59');
+    $this->assertEquals('test59_example_com', $domain->id(), 'Last domain is test59');
     $domains_old = $domains;
 
     $admin = $this->drupalCreateUser([
@@ -65,15 +65,15 @@ class DomainListWeightTest extends DomainTestBase {
     foreach ($domains as $domain) {
       // Weights should be the same one page 1 except for the one we changed.
       if ($domain->id() == 'one_example_com') {
-        $this->assert($domain->getWeight() == 61, 'Weight set to 61 ' . $domain->getWeight());
+        $this->assertEquals(61, $domain->getWeight(), 'Weight set to 61 ' . $domain->getWeight());
       }
       else {
-        $this->assert($domain->getWeight() == $domains_old[$domain->id()]->getWeight() . 'Weights unchanged');
+        $this->assertEquals($domains_old[$domain->id()]->getWeight(), $domain->getWeight(), 'Weights unchanged');
       }
       $i++;
     }
     // The last domain should be one_example_com.
-    $this->assert($domain->id() == 'one_example_com', 'Last domain is one');
+    $this->assertEquals('one_example_com', $domain->id(), 'Last domain is one');
 
     // Go to page two.
     $this->clickLink('Next');
@@ -96,10 +96,10 @@ class DomainListWeightTest extends DomainTestBase {
     $i = 1;
     foreach ($domains as $domain) {
       if ($domain->id() == 'one_example_com') {
-        $this->assert($domain->getWeight() == 2, 'Weight set to 2');
+        $this->assertEquals(2, $domain->getWeight(), 'Weight set to 2');
       }
       else {
-        $this->assert($domain->getWeight() == $domains_old[$domain->id()]->getWeight() . 'Weights unchanged');
+        $this->assertEquals($domains_old[$domain->id()]->getWeight(), $domain->getWeight(), 'Weights unchanged');
       }
     }
     // The last domain should be test59_example_com.

--- a/domain/tests/src/Functional/DomainListWeightTest.php
+++ b/domain/tests/src/Functional/DomainListWeightTest.php
@@ -14,12 +14,12 @@ class DomainListWeightTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'user'];
+  protected static $modules = ['domain', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 60 domains. We paginate at 50.

--- a/domain/tests/src/Functional/DomainNavBlockTest.php
+++ b/domain/tests/src/Functional/DomainNavBlockTest.php
@@ -51,7 +51,7 @@ class DomainNavBlockTest extends DomainTestBase {
         $this->findLink($domain->label());
       }
       else {
-        $this->assertNoRaw($domain->label());
+        $this->assertSession()->responseNotContains($domain->label());
       }
     }
     // Let the anon user view disabled domains. All links should appear.
@@ -75,7 +75,7 @@ class DomainNavBlockTest extends DomainTestBase {
     // Confirm domain links.
     foreach ($domains as $id => $domain) {
       $this->findLink($domain->getHostname());
-      $this->assertRaw($domain->buildUrl(base_path() . 'user/login'));
+      $this->assertSession()->responseContains($domain->buildUrl(base_path() . 'user/login'));
     }
 
     // Now update the configuration and test again.
@@ -90,7 +90,7 @@ class DomainNavBlockTest extends DomainTestBase {
     // Confirm domain links.
     foreach ($domains as $id => $domain) {
       $this->findLink($domain->getPath());
-      $this->assertRaw($domain->getPath());
+      $this->assertSession()->responseContains($domain->getPath());
     }
   }
 

--- a/domain/tests/src/Functional/DomainNavBlockTest.php
+++ b/domain/tests/src/Functional/DomainNavBlockTest.php
@@ -16,7 +16,7 @@ class DomainNavBlockTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'node', 'block'];
+  protected static $modules = ['domain', 'node', 'block'];
 
   /**
    * Test domain navigation block.

--- a/domain/tests/src/Functional/DomainNegotiatorTest.php
+++ b/domain/tests/src/Functional/DomainNegotiatorTest.php
@@ -38,7 +38,7 @@ class DomainNegotiatorTest extends DomainTestBase {
     // Test the response of the default home page.
     foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
-      $this->assertRaw($domain->label(), 'Loaded the proper domain.');
+      $this->assertSession()->responseContains($domain->label());
     }
   }
 

--- a/domain/tests/src/Functional/DomainNegotiatorTest.php
+++ b/domain/tests/src/Functional/DomainNegotiatorTest.php
@@ -16,7 +16,7 @@ class DomainNegotiatorTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_test', 'block'];
+  protected static $modules = ['domain', 'domain_test', 'block'];
 
   /**
    * Tests the handling of an inbound request.

--- a/domain/tests/src/Functional/DomainReferencesTest.php
+++ b/domain/tests/src/Functional/DomainReferencesTest.php
@@ -17,7 +17,7 @@ class DomainReferencesTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_access',
     'field',
@@ -28,7 +28,7 @@ class DomainReferencesTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain/tests/src/Functional/DomainReferencesTest.php
+++ b/domain/tests/src/Functional/DomainReferencesTest.php
@@ -90,10 +90,10 @@ class DomainReferencesTest extends DomainTestBase {
     // Check that three values are set.
     $manager = \Drupal::service('domain.element_manager');
     $values = $manager->getFieldValues($testuser, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 3, 'User saved with three domain admin records.');
+    $this->assertCount(3, $values, 'User saved with three domain admin records.');
     // Check that no access fields are set.
     $values = $manager->getFieldValues($testuser, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain access records.');
+    $this->assertCount(2, $values, 'User saved with two domain access records.');
 
     // Now login as a user with limited rights. This is user 4.
     $account = $this->drupalCreateUser([
@@ -105,10 +105,10 @@ class DomainReferencesTest extends DomainTestBase {
     $this->addDomainsToEntity('user', $account->id(), $ids, DOMAIN_ADMIN_FIELD);
     $limited_admin = $storage->load($account->id());
     $values = $manager->getFieldValues($limited_admin, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
+    $this->assertCount(2, $values, 'User saved with two domain admin records.');
     // Check that no access fields are set.
     $values = $manager->getFieldValues($limited_admin, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 0, 'User saved with no domain access records.');
+    $this->assertCount(0, $values, 'User saved with no domain access records.');
 
     // Now edit user 3 as user 4 with limited rights.
     $this->drupalLogin($account);
@@ -145,10 +145,10 @@ class DomainReferencesTest extends DomainTestBase {
     $testuser = $storage->load($testuser->id());
     // Check that two values are set.
     $values = $manager->getFieldValues($testuser, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
+    $this->assertCount(2, $values, 'User saved with two domain admin records.');
     // Check that no access fields are set.
     $values = $manager->getFieldValues($testuser, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain access records.');
+    $this->assertCount(2, $values, 'User saved with two domain access records.');
 
     // Now login as a user with different limited rights. This is user 5.
     $new_account = $this->drupalCreateUser([
@@ -163,9 +163,9 @@ class DomainReferencesTest extends DomainTestBase {
 
     $new_admin = $storage->load($new_account->id());
     $values = $manager->getFieldValues($new_admin, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
+    $this->assertCount(2, $values, 'User saved with two domain admin records.');
     $values = $manager->getFieldValues($new_admin, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain access records.');
+    $this->assertCount(2, $values, 'User saved with two domain access records.');
 
     // Now edit the user as someone with limited rights.
     $storage->resetCache([$new_admin->id()]);
@@ -211,9 +211,9 @@ class DomainReferencesTest extends DomainTestBase {
     $testuser = $storage->load($testuser->id());
     // Check that two values are set.
     $values = $manager->getFieldValues($testuser, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain admin records.');
+    $this->assertCount(2, $values, 'User saved with two domain admin records.');
     $values = $manager->getFieldValues($testuser, DOMAIN_ACCESS_FIELD);
-    $this->assert(count($values) == 3, 'User saved with three domain access records.');
+    $this->assertCount(3, $values, 'User saved with three domain access records.');
 
   }
 

--- a/domain/tests/src/Functional/DomainTestBase.php
+++ b/domain/tests/src/Functional/DomainTestBase.php
@@ -42,7 +42,7 @@ abstract class DomainTestBase extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'node'];
+  protected static $modules = ['domain', 'node'];
 
   /**
    * We use the standard profile for testing.
@@ -61,7 +61,7 @@ abstract class DomainTestBase extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Set the base hostname for domains.

--- a/domain/tests/src/Functional/DomainTokenTest.php
+++ b/domain/tests/src/Functional/DomainTokenTest.php
@@ -38,10 +38,10 @@ class DomainTokenTest extends DomainTestBase {
     // Test the response of the default home page.
     foreach (\Drupal::entityTypeManager()->getStorage('domain')->loadMultiple() as $domain) {
       $this->drupalGet($domain->getPath());
-      $this->assertRaw($domain->label(), 'Loaded the proper domain.');
-      $this->assertRaw('<th>Token</th>', 'Token values printed.');
+      $this->assertSession()->responseContains($domain->label());
+      $this->assertSession()->responseContains('<th>Token</th>');
       foreach ($this->tokenList() as $token => $callback) {
-        $this->assertRaw("<td>$token</td>", "$token found correctly.");
+        $this->assertSession()->responseContains("<td>$token</td>");
         // The URL token is sensitive to the path, which is /user, but that
         // does not come across when making the callback outside of a request
         // context.
@@ -52,7 +52,7 @@ class DomainTokenTest extends DomainTestBase {
             $value .= '/';
           }
         }
-        $this->assertRaw('<td>' . $value . '</td>', 'Value set correctly to ' . $value);
+        $this->assertSession()->responseContains('<td>' . $value . '</td>');
       }
     }
   }

--- a/domain/tests/src/Functional/DomainTokenTest.php
+++ b/domain/tests/src/Functional/DomainTokenTest.php
@@ -16,7 +16,7 @@ class DomainTokenTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'block'];
+  protected static $modules = ['domain', 'block'];
 
   /**
    * Tests the handling of an inbound request.

--- a/domain/tests/src/Functional/DomainValidatorTest.php
+++ b/domain/tests/src/Functional/DomainValidatorTest.php
@@ -71,7 +71,7 @@ class DomainValidatorTest extends DomainTestBase {
     }
     catch (ConfigValueException $e) {
       $expected_message = "The hostname ($test_hostname) is already registered.";
-      $this->assertEqual($expected_message, $e->getMessage());
+      $this->assertEquals($expected_message, $e->getMessage());
     }
     // Test the two configurable options.
     $config = $this->config('domain.settings');

--- a/domain/tests/src/Functional/DomainViewsAccessTest.php
+++ b/domain/tests/src/Functional/DomainViewsAccessTest.php
@@ -14,7 +14,7 @@ class DomainViewsAccessTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'node', 'views', 'block'];
+  protected static $modules = ['domain', 'node', 'views', 'block'];
 
   /**
    * Test inactive domain.

--- a/domain/tests/src/Functional/DomainViewsAccessTest.php
+++ b/domain/tests/src/Functional/DomainViewsAccessTest.php
@@ -39,22 +39,22 @@ class DomainViewsAccessTest extends DomainTestBase {
       $path = $domain->getPath() . 'domain-views-access';
       $this->DrupalGet($path);
       if (in_array($domain->id(), $allowed)) {
-        $this->assertResponse('200', 'Access allowed');
-        $this->assertRaw('admin');
-        $this->assertRaw($this->user->getAccountName());
+        $this->assertSession()->statusCodeEquals('200');
+        $this->assertSession()->responseContains('admin');
+        $this->assertSession()->responseContains($this->user->getAccountName());
       }
       else {
-        $this->assertResponse('403', 'Access denied');
-        $this->assertNoRaw('admin');
-        $this->assertNoRaw($this->user->getAccountName());
+        $this->assertSession()->statusCodeEquals('403');
+        $this->assertSession()->responseNotContains('admin');
+        $this->assertSession()->responseNotContains($this->user->getAccountName());
       }
       // Test the block on another page.
       $this->drupalGet($domain->getPath());
       if (in_array($domain->id(), $allowed)) {
-        $this->assertRaw($this->user->getAccountName());
+        $this->assertSession()->responseContains($this->user->getAccountName());
       }
       else {
-        $this->assertNoRaw($this->user->getAccountName());
+        $this->assertSession()->responseNotContains($this->user->getAccountName());
       }
     }
   }

--- a/domain/tests/src/Functional/Views/ActiveDomainDefaultArgumentTest.php
+++ b/domain/tests/src/Functional/Views/ActiveDomainDefaultArgumentTest.php
@@ -23,7 +23,7 @@ class ActiveDomainDefaultArgumentTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['node', 'domain', 'domain_access', 'domain_test_views'];
+  protected static $modules = ['node', 'domain', 'domain_access', 'domain_test_views'];
 
   /**
    * Data mapping.
@@ -35,7 +35,7 @@ class ActiveDomainDefaultArgumentTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp($import_test_views = TRUE) {
+  protected function setUp($import_test_views = TRUE): void {
     parent::setUp();
     $this->domainCreateTestDomains(3);
     $this->createTestData();

--- a/domain/tests/src/Kernel/DomainConfigTest.php
+++ b/domain/tests/src/Kernel/DomainConfigTest.php
@@ -16,12 +16,12 @@ class DomainConfigTest extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_config_schema_test'];
+  protected static $modules = ['domain', 'domain_config_schema_test'];
 
   /**
    * Test setup.
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('domain');

--- a/domain/tests/src/Kernel/DomainHookTest.php
+++ b/domain/tests/src/Kernel/DomainHookTest.php
@@ -27,7 +27,7 @@ class DomainHookTest extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_test', 'user', 'node'];
+  protected static $modules = ['domain', 'domain_test', 'user', 'node'];
 
   /**
    * Domain id key.
@@ -70,7 +70,7 @@ class DomainHookTest extends KernelTestBase {
   /**
    * Test setup.
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create a domain.

--- a/domain/tests/src/Kernel/DomainVariableSchemeTest.php
+++ b/domain/tests/src/Kernel/DomainVariableSchemeTest.php
@@ -19,7 +19,7 @@ class DomainVariableSchemeTest extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain'];
+  protected static $modules = ['domain'];
 
   /**
    * Domain id key.
@@ -48,7 +48,7 @@ class DomainVariableSchemeTest extends KernelTestBase {
   /**
    * Test setup.
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create a domain.

--- a/domain/tests/src/Traits/DomainTestTrait.php
+++ b/domain/tests/src/Traits/DomainTestTrait.php
@@ -53,7 +53,7 @@ trait DomainTestTrait {
       if ($i === 0) {
         $hostname = $base_hostname;
         $machine_name = 'example.com';
-        $name = 'Example';
+        $name = 'Example base domain';
       }
       elseif (!empty($list[$i])) {
         $hostname = $list[$i] . '.' . $base_hostname;

--- a/domain_access/src/DomainAccessManager.php
+++ b/domain_access/src/DomainAccessManager.php
@@ -92,7 +92,7 @@ class DomainAccessManager implements DomainAccessManagerInterface {
    * {@inheritdoc}
    */
   public static function getAllValue(FieldableEntityInterface $entity) {
-    return $entity->hasField(DOMAIN_ACCESS_ALL_FIELD) ? $entity->get(DOMAIN_ACCESS_ALL_FIELD)->value : NULL;
+    return $entity->hasField(DOMAIN_ACCESS_ALL_FIELD) ? (bool) $entity->get(DOMAIN_ACCESS_ALL_FIELD)->value : NULL;
   }
 
   /**

--- a/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
@@ -33,17 +33,17 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
 
     // Visit the article field administration page.
     $this->drupalGet('admin/structure/types/manage/article/fields');
-    $this->assertResponse(200, 'Manage fields page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the field.
-    $this->assertText($label, 'Domain form field found.');
+    $this->assertSession()->pageTextContains($label);
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
-    $this->assertResponse(200, 'Manage field display page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the field.
-    $this->assertText($label, 'Domain form field found.');
+    $this->assertSession()->pageTextContains($label);
   }
 
   /**
@@ -66,16 +66,16 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
 
     // Visit the article field display administration page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the new field exists on the page.
-    $this->assertText($label, 'Found the domain field instance.');
+    $this->assertSession()->pageTextContains($label);
 
     // We expect to find 5 domain options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
-      $this->assertRaw($string, 'Found the domain option.');
+      $this->assertSession()->responseContains($string, 'Found the domain option.');
       if (!isset($one)) {
         $one = $domain->id();
         continue;
@@ -90,8 +90,8 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
     $edit["field_domain_access[{$one}]"] = TRUE;
     $edit["field_domain_access[{$two}]"] = TRUE;
     $edit["field_domain_all_affiliates[value]"] = 1;
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
-    $this->assertResponse(200);
+    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
     // Check that two values are set.
     $values = \Drupal::service('domain_access.manager')->getAccessValues($node);

--- a/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
@@ -90,7 +90,7 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
     $edit["field_domain_access[{$one}]"] = TRUE;
     $edit["field_domain_access[{$two}]"] = TRUE;
     $edit["field_domain_all_affiliates[value]"] = 1;
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->submitForm($edit, 'Save');
     $this->assertSession()->statusCodeEquals(200);
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
     // Check that two values are set.

--- a/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessAllAffiliatesTest.php
@@ -16,7 +16,7 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
 
   /**
    * Tests that the module installed its field correctly.
@@ -75,7 +75,7 @@ class DomainAccessAllAffiliatesTest extends DomainTestBase {
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
-      $this->assertSession()->responseContains($string, 'Found the domain option.');
+      $this->assertSession()->responseContains($string);
       if (!isset($one)) {
         $one = $domain->id();
         continue;

--- a/domain_access/tests/src/Functional/DomainAccessContentUrlsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessContentUrlsTest.php
@@ -17,12 +17,12 @@ class DomainAccessContentUrlsTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'node', 'user'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'node', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 4 domains.

--- a/domain_access/tests/src/Functional/DomainAccessDefaultValueTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessDefaultValueTest.php
@@ -18,7 +18,7 @@ class DomainAccessDefaultValueTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
 
   /**
    * Test the usage of DomainAccessManager::getDefaultValue().

--- a/domain_access/tests/src/Functional/DomainAccessDefaultValueTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessDefaultValueTest.php
@@ -39,21 +39,21 @@ class DomainAccessDefaultValueTest extends DomainTestBase {
 
     // Visit the article field display administration page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the new field exists on the page.
-    $this->assertText('Domain Access', 'Found the domain field instance.');
-    $this->assertRaw('name="field_domain_access[example_com]" value="example_com" checked="checked"', 'Default domain selected.');
+    $this->assertSession()->pageTextContains('Domain Access');
+    $this->assertSession()->responseContains('name="field_domain_access[example_com]" value="example_com" checked="checked"');
     // Check the all affiliates field.
-    $this->assertText('Send to all affiliates', 'Found the all affiliates field instance.');
-    $this->assertNoRaw('name="field_domain_all_affiliates[value]" value="1" checked="checked"', 'All affiliates not selected.');
+    $this->assertSession()->pageTextContains('Send to all affiliates');
+    $this->assertSession()->responseNotContains('name="field_domain_all_affiliates[value]" value="1" checked="checked"');
 
     // Now save the node with the values set.
     $edit = [
       'title[0][value]' => 'Test node',
       'field_domain_access[example_com]' => 'example_com',
     ];
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
+    $this->submitForm('node/add/article', $edit, 'Save');
 
     // Load the node.
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
@@ -77,13 +77,13 @@ class DomainAccessDefaultValueTest extends DomainTestBase {
     $this->drupalLogin($this->test_user);
 
     $this->drupalGet('node/1/edit');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Now save the node with the values set.
     $edit = [
       'title[0][value]' => 'Test node update',
     ];
-    $this->drupalPostForm('node/1/edit', $edit, 'Save');
+    $this->submitForm('node/1/edit', $edit, 'Save');
 
     // Load the node.
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);

--- a/domain_access/tests/src/Functional/DomainAccessDefaultValueTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessDefaultValueTest.php
@@ -53,7 +53,7 @@ class DomainAccessDefaultValueTest extends DomainTestBase {
       'title[0][value]' => 'Test node',
       'field_domain_access[example_com]' => 'example_com',
     ];
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->submitForm($edit, 'Save');
 
     // Load the node.
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
@@ -83,7 +83,8 @@ class DomainAccessDefaultValueTest extends DomainTestBase {
     $edit = [
       'title[0][value]' => 'Test node update',
     ];
-    $this->submitForm('node/1/edit', $edit, 'Save');
+    $this->drupalGet('node/1/edit');
+    $this->submitForm($edit, 'Save');
 
     // Load the node.
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);

--- a/domain_access/tests/src/Functional/DomainAccessElementTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessElementTest.php
@@ -94,7 +94,7 @@ class DomainAccessElementTest extends DomainTestBase {
     $values = $manager->getAccessValues($node);
     $this->assertCount(3, $values, 'Node saved with three domain records.');
     $value = $manager->getAllValue($node);
-    $this->assertEquals(1, $value, 'Node saved to all affiliates.');
+    $this->assertTrue($value, 'Node saved to all affiliates.');
 
     // Now login as a user with limited rights.
     $account = $this->drupalCreateUser([
@@ -145,7 +145,7 @@ class DomainAccessElementTest extends DomainTestBase {
     $values = $manager->getAccessValues($node);
     $this->assertCount(2, $values, 'Node saved with two domain records.');
     $value = $manager->getAllValue($node);
-    $this->assertCount(1, $value, 'Node saved to all affiliates.');
+    $this->assertTrue($value, 'Node saved to all affiliates.');
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessElementTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessElementTest.php
@@ -92,9 +92,9 @@ class DomainAccessElementTest extends DomainTestBase {
     // Check that two values are set.
     $manager = \Drupal::service('domain_access.manager');
     $values = $manager->getAccessValues($node);
-    $this->assert(count($values) == 3, 'Node saved with three domain records.');
+    $this->assertCount(3, $values, 'Node saved with three domain records.');
     $value = $manager->getAllValue($node);
-    $this->assert($value == 1, 'Node saved to all affiliates.');
+    $this->assertEquals(1, $value, 'Node saved to all affiliates.');
 
     // Now login as a user with limited rights.
     $account = $this->drupalCreateUser([
@@ -107,9 +107,9 @@ class DomainAccessElementTest extends DomainTestBase {
     $user_storage = \Drupal::entityTypeManager()->getStorage('user');
     $user = $user_storage->load($account->id());
     $values = $manager->getAccessValues($user);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $this->assertCount(2, $values, 'User saved with two domain records.');
     $value = $manager->getAllValue($user);
-    $this->assert($value == 0, 'User not saved to all affiliates.');
+    $this->assertCount(0, $value, 'User not saved to all affiliates.');
 
     $this->drupalLogin($account);
 
@@ -143,9 +143,9 @@ class DomainAccessElementTest extends DomainTestBase {
     $node = $storage->load($node->id());
     // Check that two values are set.
     $values = $manager->getAccessValues($node);
-    $this->assert(count($values) == 2, 'Node saved with two domain records.');
+    $this->assertCount(2, $values, 'Node saved with two domain records.');
     $value = $manager->getAllValue($node);
-    $this->assert($value == 1, 'Node saved to all affiliates.');
+    $this->assertCount(1, $value, 'Node saved to all affiliates.');
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessElementTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessElementTest.php
@@ -16,7 +16,7 @@ class DomainAccessElementTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_access',
     'field',
@@ -27,7 +27,7 @@ class DomainAccessElementTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.
@@ -109,7 +109,7 @@ class DomainAccessElementTest extends DomainTestBase {
     $values = $manager->getAccessValues($user);
     $this->assertCount(2, $values, 'User saved with two domain records.');
     $value = $manager->getAllValue($user);
-    $this->assertCount(0, $value, 'User not saved to all affiliates.');
+    $this->assertFalse($value, 'User not saved to all affiliates.');
 
     $this->drupalLogin($account);
 

--- a/domain_access/tests/src/Functional/DomainAccessEntityFieldTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessEntityFieldTest.php
@@ -18,7 +18,7 @@ class DomainAccessEntityFieldTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_access',
     'domain_access_test',
@@ -31,7 +31,7 @@ class DomainAccessEntityFieldTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain_access/tests/src/Functional/DomainAccessEntityFieldTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessEntityFieldTest.php
@@ -71,10 +71,10 @@ class DomainAccessEntityFieldTest extends DomainTestBase {
     ]);
     $this->drupalLogin($this->admin_user);
     $this->drupalGet('admin/structure/taxonomy/manage/domain_access/overview/fields');
-    $this->assertResponse(200, 'Manage fields page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertText('Domain Access', 'Domain form field found.');
+    $this->assertSession()->pageTextContains('Domain Access');
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
@@ -16,7 +16,7 @@ class DomainAccessEntityReferenceTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
 
   /**
    * Tests that the module installed its field correctly.

--- a/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
@@ -87,7 +87,7 @@ class DomainAccessEntityReferenceTest extends DomainTestBase {
     $edit['title[0][value]'] = 'Test node';
     $edit["field_domain_access[{$one}]"] = TRUE;
     $edit["field_domain_access[{$two}]"] = TRUE;
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->submitForm($edit, 'Save');
     $this->assertSession()->statusCodeEquals(200);
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
     // Check that two values are set.

--- a/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessEntityReferenceTest.php
@@ -32,17 +32,17 @@ class DomainAccessEntityReferenceTest extends DomainTestBase {
 
     // Visit the article field administration page.
     $this->drupalGet('admin/structure/types/manage/article/fields');
-    $this->assertResponse(200, 'Manage fields page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertText('Domain Access', 'Domain form field found.');
+    $this->assertSession()->pageTextContains('Domain Access');
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
-    $this->assertResponse(200, 'Manage field display page accessed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertText('Domain Access', 'Domain form field found.');
+    $this->assertSession()->pageTextContains('Domain Access');
   }
 
   /**
@@ -64,16 +64,16 @@ class DomainAccessEntityReferenceTest extends DomainTestBase {
 
     // Visit the article field display administration page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the new field exists on the page.
-    $this->assertText('Domain Access', 'Found the domain field instance.');
+    $this->assertSession()->pageTextContains('Domain Access');
 
     // We expect to find 5 domain options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
-      $this->assertRaw($string, 'Found the domain option.');
+      $this->assertSession()->responseContains($string);
       if (!isset($one)) {
         $one = $domain->id();
         continue;
@@ -87,8 +87,8 @@ class DomainAccessEntityReferenceTest extends DomainTestBase {
     $edit['title[0][value]'] = 'Test node';
     $edit["field_domain_access[{$one}]"] = TRUE;
     $edit["field_domain_access[{$two}]"] = TRUE;
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
-    $this->assertResponse(200);
+    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
     $node = \Drupal::entityTypeManager()->getStorage('node')->load(1);
     // Check that two values are set.
     $values = \Drupal::service('domain_access.manager')->getAccessValues($node);

--- a/domain_access/tests/src/Functional/DomainAccessFieldTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessFieldTest.php
@@ -98,7 +98,7 @@ class DomainAccessFieldTest extends DomainTestBase {
     $edit = [];
     $edit['title[0][value]'] = $this->randomMachineName(8);
     $edit['body[0][value]'] = $this->randomMachineName(16);
-    $this->submitForm('node/add/article', $edit, t('Save'));
+    $this->submitForm($edit, t('Save'));
 
     // Check that the node exists in the database.
     $node = $this->drupalGetNodeByTitle($edit['title[0][value]']);
@@ -192,7 +192,7 @@ class DomainAccessFieldTest extends DomainTestBase {
     $edit = [];
     $edit['name'] = $this->randomMachineName();
 
-    $this->submitForm($user_edit_page, $edit, t('Save'));
+    $this->submitForm($edit, t('Save'));
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessFieldTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessFieldTest.php
@@ -17,7 +17,7 @@ class DomainAccessFieldTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_access',
     'field',
@@ -28,7 +28,7 @@ class DomainAccessFieldTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.
@@ -64,18 +64,18 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/article');
-    $this->assertSession()->statusCodeEquals(200, 'Article creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     foreach ($domains as $domain) {
       if ($domain->id() == $active_domain) {
-        $this->assertSession()->responseContains('>' . $domain->label() . '</label>', 'Domain form item found.');
+        $this->assertSession()->responseContains('>' . $domain->label() . '</label>');
       }
       else {
-        $this->assertSession()->responseNotContains('>' . $domain->label() . '</label>', 'Domain form item not found.');
+        $this->assertSession()->responseNotContains('>' . $domain->label() . '</label>');
       }
     }
-    $this->assertSession()->pageTextNotContains($label, 'All affiliates field not found.');
+    $this->assertSession()->pageTextNotContains($label);
 
     // Test a user who can access no domain settings.
     $user3 = $this->drupalCreateUser(['create article content']);
@@ -83,13 +83,13 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/article');
-    $this->assertSession()->statusCodeEquals(200, 'Article creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     foreach ($domains as $domain) {
-      $this->assertSession()->pageTextNotContains($domain->label(), 'Domain form item not found.');
+      $this->assertSession()->pageTextNotContains($domain->label());
     }
-    $this->assertSession()->pageTextNotContains($label, 'All affiliates field not found.');
+    $this->assertSession()->pageTextNotContains($label);
 
     // Attempt saving the node.
     // The domain/domain affiliates fields are not accessible to this user.
@@ -110,11 +110,11 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the account creation page.
     $this->drupalGet('admin/people/create');
-    $this->assertSession()->statusCodeEquals(200, 'User creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     foreach ($domains as $domain) {
-      $this->assertSession()->pageTextContains($domain->label(), 'Domain form item found.');
+      $this->assertSession()->pageTextContains($domain->label());
     }
 
     // Test a user who can assign users to some domains.
@@ -125,15 +125,15 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the account creation page.
     $this->drupalGet('admin/people/create');
-    $this->assertSession()->statusCodeEquals(200, 'User creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     foreach ($domains as $domain) {
       if ($domain->id() == $active_domain) {
-        $this->assertSession()->responseContains('>' . $domain->label() . '</label>', 'Domain form item found.');
+        $this->assertSession()->responseContains('>' . $domain->label() . '</label>');
       }
       else {
-        $this->assertSession()->responseNotContains('>' . $domain->label() . '</label>', 'Domain form item not found.');
+        $this->assertSession()->responseNotContains('>' . $domain->label() . '</label>');
       }
     }
 
@@ -143,11 +143,11 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the account creation page.
     $this->drupalGet('admin/people/create');
-    $this->assertSession()->statusCodeEquals(200, 'User creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     foreach ($domains as $domain) {
-      $this->assertSession()->pageTextNotContains($domain->label(), 'Domain form item not found.');
+      $this->assertSession()->pageTextNotContains($domain->label());
     }
 
     // Test a user who can access all domain settings.
@@ -165,14 +165,14 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/' . $type->id());
-    $this->assertSession()->statusCodeEquals(200, $type->id() . ' creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
-      $this->assertSession()->pageTextContains($domain->label(), 'Domain form item found.');
+      $this->assertSession()->pageTextContains($domain->label());
     }
-    $this->assertSession()->pageTextContains($label, 'All affiliates field found.');
+    $this->assertSession()->pageTextContains($label);
 
     // Test user without access to affiliates field editing their user page.
     $user8 = $this->drupalCreateUser(['change own username']);
@@ -183,10 +183,10 @@ class DomainAccessFieldTest extends DomainTestBase {
     // Check for the form options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
-      $this->assertSession()->pageTextNotContains($domain->label(), 'Domain form item not found.');
+      $this->assertSession()->pageTextNotContains($domain->label());
     }
 
-    $this->assertSession()->pageTextNotContains($label, 'All affiliates field not found.');
+    $this->assertSession()->pageTextNotContains($label);
 
     // Change own username.
     $edit = [];

--- a/domain_access/tests/src/Functional/DomainAccessFieldTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessFieldTest.php
@@ -47,14 +47,14 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200, 'Article creation found.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for the form options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
-      $this->assertText($domain->label(), 'Domain form item found.');
+      $this->assertSession()->pageTextContains($domain->label());
     }
-    $this->assertText($label, 'All affiliates field found.');
+    $this->assertSession()->pageTextContains($label);
 
     // Test a user who can access some domain settings.
     $user2 = $this->drupalCreateUser(['create article content', 'publish to any assigned domain']);
@@ -64,18 +64,18 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200, 'Article creation found.');
+    $this->assertSession()->statusCodeEquals(200, 'Article creation found.');
 
     // Check for the form options.
     foreach ($domains as $domain) {
       if ($domain->id() == $active_domain) {
-        $this->assertRaw('>' . $domain->label() . '</label>', 'Domain form item found.');
+        $this->assertSession()->responseContains('>' . $domain->label() . '</label>', 'Domain form item found.');
       }
       else {
-        $this->assertNoRaw('>' . $domain->label() . '</label>', 'Domain form item not found.');
+        $this->assertSession()->responseNotContains('>' . $domain->label() . '</label>', 'Domain form item not found.');
       }
     }
-    $this->assertNoText($label, 'All affiliates field not found.');
+    $this->assertSession()->pageTextNotContains($label, 'All affiliates field not found.');
 
     // Test a user who can access no domain settings.
     $user3 = $this->drupalCreateUser(['create article content']);
@@ -83,13 +83,13 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200, 'Article creation found.');
+    $this->assertSession()->statusCodeEquals(200, 'Article creation found.');
 
     // Check for the form options.
     foreach ($domains as $domain) {
-      $this->assertNoText($domain->label(), 'Domain form item not found.');
+      $this->assertSession()->pageTextNotContains($domain->label(), 'Domain form item not found.');
     }
-    $this->assertNoText($label, 'All affiliates field not found.');
+    $this->assertSession()->pageTextNotContains($label, 'All affiliates field not found.');
 
     // Attempt saving the node.
     // The domain/domain affiliates fields are not accessible to this user.
@@ -98,7 +98,7 @@ class DomainAccessFieldTest extends DomainTestBase {
     $edit = [];
     $edit['title[0][value]'] = $this->randomMachineName(8);
     $edit['body[0][value]'] = $this->randomMachineName(16);
-    $this->drupalPostForm('node/add/article', $edit, t('Save'));
+    $this->submitForm('node/add/article', $edit, t('Save'));
 
     // Check that the node exists in the database.
     $node = $this->drupalGetNodeByTitle($edit['title[0][value]']);
@@ -110,11 +110,11 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the account creation page.
     $this->drupalGet('admin/people/create');
-    $this->assertResponse(200, 'User creation found.');
+    $this->assertSession()->statusCodeEquals(200, 'User creation found.');
 
     // Check for the form options.
     foreach ($domains as $domain) {
-      $this->assertText($domain->label(), 'Domain form item found.');
+      $this->assertSession()->pageTextContains($domain->label(), 'Domain form item found.');
     }
 
     // Test a user who can assign users to some domains.
@@ -125,15 +125,15 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the account creation page.
     $this->drupalGet('admin/people/create');
-    $this->assertResponse(200, 'User creation found.');
+    $this->assertSession()->statusCodeEquals(200, 'User creation found.');
 
     // Check for the form options.
     foreach ($domains as $domain) {
       if ($domain->id() == $active_domain) {
-        $this->assertRaw('>' . $domain->label() . '</label>', 'Domain form item found.');
+        $this->assertSession()->responseContains('>' . $domain->label() . '</label>', 'Domain form item found.');
       }
       else {
-        $this->assertNoRaw('>' . $domain->label() . '</label>', 'Domain form item not found.');
+        $this->assertSession()->responseNotContains('>' . $domain->label() . '</label>', 'Domain form item not found.');
       }
     }
 
@@ -143,11 +143,11 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the account creation page.
     $this->drupalGet('admin/people/create');
-    $this->assertResponse(200, 'User creation found.');
+    $this->assertSession()->statusCodeEquals(200, 'User creation found.');
 
     // Check for the form options.
     foreach ($domains as $domain) {
-      $this->assertNoText($domain->label(), 'Domain form item not found.');
+      $this->assertSession()->pageTextNotContains($domain->label(), 'Domain form item not found.');
     }
 
     // Test a user who can access all domain settings.
@@ -165,14 +165,14 @@ class DomainAccessFieldTest extends DomainTestBase {
 
     // Visit the article creation page.
     $this->drupalGet('node/add/' . $type->id());
-    $this->assertResponse(200, $type->id() . ' creation found.');
+    $this->assertSession()->statusCodeEquals(200, $type->id() . ' creation found.');
 
     // Check for the form options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
-      $this->assertText($domain->label(), 'Domain form item found.');
+      $this->assertSession()->pageTextContains($domain->label(), 'Domain form item found.');
     }
-    $this->assertText($label, 'All affiliates field found.');
+    $this->assertSession()->pageTextContains($label, 'All affiliates field found.');
 
     // Test user without access to affiliates field editing their user page.
     $user8 = $this->drupalCreateUser(['change own username']);
@@ -183,16 +183,16 @@ class DomainAccessFieldTest extends DomainTestBase {
     // Check for the form options.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
-      $this->assertNoText($domain->label(), 'Domain form item not found.');
+      $this->assertSession()->pageTextNotContains($domain->label(), 'Domain form item not found.');
     }
 
-    $this->assertNoText($label, 'All affiliates field not found.');
+    $this->assertSession()->pageTextNotContains($label, 'All affiliates field not found.');
 
     // Change own username.
     $edit = [];
     $edit['name'] = $this->randomMachineName();
 
-    $this->drupalPostForm($user_edit_page, $edit, t('Save'));
+    $this->submitForm($user_edit_page, $edit, t('Save'));
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessGrantsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessGrantsTest.php
@@ -61,11 +61,11 @@ class DomainAccessGrantsTest extends DomainTestBase {
       $path = $domain->getPath() . 'node/' . $node1->id();
       $this->drupalGet($path);
       if ($domain->id() == $active_domain) {
-        $this->assertResponse(200);
-        $this->assertRaw($node1->getTitle(), 'Article found on domain.');
+        $this->assertSession()->statusCodeEquals(200);
+        $this->assertSession()->responseContains($node1->getTitle(), 'Article found on domain.');
       }
       else {
-        $this->assertResponse(403);
+        $this->assertSession()->statusCodeEquals(403);
       }
     }
 
@@ -80,8 +80,8 @@ class DomainAccessGrantsTest extends DomainTestBase {
     foreach ($domains as $domain) {
       $path = $domain->getPath() . 'node/' . $node2->id();
       $this->drupalGet($path);
-      $this->assertResponse(200);
-      $this->assertRaw($node2->getTitle(), 'Article found on domain.');
+      $this->assertSession()->statusCodeEquals(200);
+      $this->assertSession()->responseContains($node2->getTitle(), 'Article found on domain.');
     }
   }
 

--- a/domain_access/tests/src/Functional/DomainAccessGrantsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessGrantsTest.php
@@ -24,12 +24,12 @@ class DomainAccessGrantsTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'node'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'node'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Ensure node_access table is clear.
@@ -62,7 +62,7 @@ class DomainAccessGrantsTest extends DomainTestBase {
       $this->drupalGet($path);
       if ($domain->id() == $active_domain) {
         $this->assertSession()->statusCodeEquals(200);
-        $this->assertSession()->responseContains($node1->getTitle(), 'Article found on domain.');
+        $this->assertSession()->responseContains($node1->getTitle());
       }
       else {
         $this->assertSession()->statusCodeEquals(403);
@@ -81,7 +81,7 @@ class DomainAccessGrantsTest extends DomainTestBase {
       $path = $domain->getPath() . 'node/' . $node2->id();
       $this->drupalGet($path);
       $this->assertSession()->statusCodeEquals(200);
-      $this->assertSession()->responseContains($node2->getTitle(), 'Article found on domain.');
+      $this->assertSession()->responseContains($node2->getTitle());
     }
   }
 

--- a/domain_access/tests/src/Functional/DomainAccessLanguageSaveTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessLanguageSaveTest.php
@@ -17,7 +17,7 @@ class DomainAccessLanguageSaveTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_access',
     'field',
@@ -29,7 +29,7 @@ class DomainAccessLanguageSaveTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain_access/tests/src/Functional/DomainAccessLanguageSaveTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessLanguageSaveTest.php
@@ -65,9 +65,9 @@ class DomainAccessLanguageSaveTest extends DomainTestBase {
     // Check that two values are set properly.
     $manager = \Drupal::service('domain_access.manager');
     $values = $manager->getAccessValues($node);
-    $this->assert(count($values) == 1, 'Node saved with one domain records.');
+    $this->assertCount(1, $values, 'Node saved with one domain records.');
     $value = $manager->getAllValue($node);
-    $this->assert($value == 1, 'Node saved to all affiliates.');
+    $this->assertEquals(TRUE, $value, 'Node saved to all affiliates.');
 
     // Create an Afrikaans translation assigned to domain 2.
     $translation = $node->addTranslation('af');
@@ -81,9 +81,9 @@ class DomainAccessLanguageSaveTest extends DomainTestBase {
     $parent_node = $storage->load(1);
     $node = $parent_node->getTranslation('af');
     $values = $manager->getAccessValues($node);
-    $this->assert(count($values) == 2, 'Node saved with two domain records.');
+    $this->assertCount(2, $values, 'Node saved with two domain records.');
     $value = $manager->getAllValue($node);
-    $this->assert($value == 0, 'Node not saved to all affiliates.');
+    $this->assertFalse($value, 'Node not saved to all affiliates.');
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessPermissionsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessPermissionsTest.php
@@ -47,12 +47,12 @@ class DomainAccessPermissionsTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'node'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'node'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     // Clear permissions for authenticated users.
     $this->config('user.role.' . RoleInterface::AUTHENTICATED_ID)->set('permissions', [])->save();

--- a/domain_access/tests/src/Functional/DomainAccessPermissionsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessPermissionsTest.php
@@ -222,19 +222,19 @@ class DomainAccessPermissionsTest extends DomainTestBase {
       $url = $domain->getPath() . 'node/add/page';
       $this->drupalGet($url);
       if ($domain->id() == $two) {
-        $this->assertResponse(200);
+        $this->assertSession()->statusCodeEquals(200);
       }
       else {
-        $this->assertResponse(403);
+        $this->assertSession()->statusCodeEquals(403);
       }
       // The user should be allowed to create articles.
       $url = $domain->getPath() . 'node/add/article';
       $this->drupalGet($url);
       if ($domain->id() == $two) {
-        $this->assertResponse(200);
+        $this->assertSession()->statusCodeEquals(200);
       }
       else {
-        $this->assertResponse(403);
+        $this->assertSession()->statusCodeEquals(403);
       }
     }
 
@@ -266,15 +266,15 @@ class DomainAccessPermissionsTest extends DomainTestBase {
       $url = $domain->getPath() . 'node/add/page';
       $this->drupalGet($url);
       if ($domain->id() == $two) {
-        $this->assertResponse(200);
+        $this->assertSession()->statusCodeEquals(200);
       }
       else {
-        $this->assertResponse(403);
+        $this->assertSession()->statusCodeEquals(403);
       }
       // The user should not be allowed to create articles.
       $url = $domain->getPath() . 'node/add/article';
       $this->drupalGet($url);
-      $this->assertResponse(403);
+      $this->assertSession()->statusCodeEquals(403);
     }
   }
 
@@ -293,7 +293,7 @@ class DomainAccessPermissionsTest extends DomainTestBase {
    */
   public function assertNodeAccess(array $ops, NodeInterface $node, AccountInterface $account) {
     foreach ($ops as $op => $result) {
-      $this->assertEqual($result, $this->accessHandler->access($node, $op, $account), 'Expected result returned.');
+      $this->assertEquals($result, $this->accessHandler->access($node, $op, $account), 'Expected result returned.');
     }
   }
 

--- a/domain_access/tests/src/Functional/DomainAccessRecordsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessRecordsTest.php
@@ -46,11 +46,11 @@ class DomainAccessRecordsTest extends DomainTestBase {
       ->fetchAll();
 
     $this->assertCount(1, $records, 'Returned the correct number of rows.');
-    $this->assertEqual($records[0]->realm, 'domain_id', 'Grant with domain_id acquired for node.');
-    $this->assertEqual($records[0]->gid, $domain->getDomainId(), 'Grant with proper id acquired for node.');
-    $this->assertEqual($records[0]->grant_view, 1, 'Grant view stored.');
-    $this->assertEqual($records[0]->grant_update, 1, 'Grant update stored.');
-    $this->assertEqual($records[0]->grant_delete, 1, 'Grant delete stored.');
+    $this->assertEquals('domain_id', $records[0]->realm, 'Grant with domain_id acquired for node.');
+    $this->assertEquals($domain->getDomainId(), $records[0]->gid, 'Grant with proper id acquired for node.');
+    $this->assertEquals(1, $records[0]->grant_view, 'Grant view stored.');
+    $this->assertEquals(1, $records[0]->grant_update, 'Grant update stored.');
+    $this->assertEquals(1, $records[0]->grant_delete, 'Grant delete stored.');
 
     // Create another article node.
     $node2 = $this->drupalCreateNode([
@@ -65,16 +65,16 @@ class DomainAccessRecordsTest extends DomainTestBase {
       ->query($query, [':nid' => $node2->id()])
       ->fetchAll();
     $this->assertCount(2, $records, 'Returned the correct number of rows.');
-    $this->assertEqual($records[0]->realm, 'domain_id', 'Grant with domain_id acquired for node.');
-    $this->assertEqual($records[0]->gid, $domain->getDomainId(), 'Grant with proper id acquired for node.');
-    $this->assertEqual($records[0]->grant_view, 1, 'Grant view stored.');
-    $this->assertEqual($records[0]->grant_update, 1, 'Grant update stored.');
-    $this->assertEqual($records[0]->grant_delete, 1, 'Grant delete stored.');
-    $this->assertEqual($records[1]->realm, 'domain_site', 'Grant with domain_site acquired for node.');
-    $this->assertEqual($records[1]->gid, 0, 'Grant with proper id acquired for node.');
-    $this->assertEqual($records[1]->grant_view, 1, 'Grant view stored.');
-    $this->assertEqual($records[1]->grant_update, 0, 'Grant update stored.');
-    $this->assertEqual($records[1]->grant_delete, 0, 'Grant delete stored.');
+    $this->assertEquals('domain_id', $records[0]->realm, 'Grant with domain_id acquired for node.');
+    $this->assertEquals($domain->getDomainId(), $records[0]->gid, 'Grant with proper id acquired for node.');
+    $this->assertEquals(1, $records[0]->grant_view, 'Grant view stored.');
+    $this->assertEquals(1, $records[0]->grant_update, 'Grant update stored.');
+    $this->assertEquals(1, $records[0]->grant_delete, 'Grant delete stored.');
+    $this->assertEquals('domain_site', $records[1]->realm, 'Grant with domain_site acquired for node.');
+    $this->assertEquals(0, $records[1]->gid, 'Grant with proper id acquired for node.');
+    $this->assertEquals(1, $records[1]->grant_view, 'Grant view stored.');
+    $this->assertEquals(0, $records[1]->grant_update, 'Grant update stored.');
+    $this->assertEquals(0, $records[1]->grant_delete, 'Grant delete stored.');
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessRecordsTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessRecordsTest.php
@@ -17,7 +17,7 @@ class DomainAccessRecordsTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'field_ui'];
 
   /**
    * Creates a node and tests the creation of node access rules.

--- a/domain_access/tests/src/Functional/DomainAccessSaveTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessSaveTest.php
@@ -50,9 +50,9 @@ class DomainAccessSaveTest extends DomainTestBase {
     // Check that two values are set properly.
     $manager = \Drupal::service('domain_access.manager');
     $values = $manager->getAccessValues($node);
-    $this->assert(count($values) == 1, 'Node saved with one domain records.');
+    $this->assertCount(1, $values, 'Node saved with one domain records.');
     $value = $manager->getAllValue($node);
-    $this->assert($value == 1, 'Node saved to all affiliates.');
+    $this->assertTrue($value, 'Node saved to all affiliates.');
 
     // Save a node with different values.
     $node = $storage->create([
@@ -68,9 +68,9 @@ class DomainAccessSaveTest extends DomainTestBase {
     // Load and check the node.
     $node = $storage->load(2);
     $values = $manager->getAccessValues($node);
-    $this->assert(count($values) == 2, 'Node saved with two domain records.');
+    $this->assertCount(2, $values, 'Node saved with two domain records.');
     $value = $manager->getAllValue($node);
-    $this->assert($value == 0, 'Node not saved to all affiliates.');
+    $this->assertFalse($value, 'Node not saved to all affiliates.');
   }
 
 }

--- a/domain_access/tests/src/Functional/DomainAccessSaveTest.php
+++ b/domain_access/tests/src/Functional/DomainAccessSaveTest.php
@@ -16,12 +16,12 @@ class DomainAccessSaveTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'field', 'user'];
+  protected static $modules = ['domain', 'domain_access', 'field', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain_access/tests/src/Kernel/DomainAccessEntityCrudTest.php
+++ b/domain_access/tests/src/Kernel/DomainAccessEntityCrudTest.php
@@ -32,12 +32,12 @@ class DomainAccessEntityCrudTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['system', 'field', 'filter', 'text', 'user', 'node', 'domain', 'domain_access'];
+  protected static $modules = ['system', 'field', 'filter', 'text', 'user', 'node', 'domain', 'domain_access'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setup();
 
     $this->entityTypeManager = $this->container->get('entity_type.manager');

--- a/domain_alias/tests/src/Functional/DomainAliasActionsTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasActionsTest.php
@@ -40,8 +40,8 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
     $patterns = ['*.' . $base, 'four.' . $base, 'five.' . $base];
     $i = 0;
     foreach ($domains as $domain) {
-      $this->assert($domain->getHostname() == $hostnames[$i], 'Hostnames set correctly');
-      $this->assert($domain->getCanonical() == $hostnames[$i], 'Canonical domains set correctly');
+      $this->assertEquals($hostnames[$i], $domain->getHostname(), 'Hostnames set correctly');
+      $this->assertEquals($hostnames[$i], $domain->getCanonical(), 'Canonical domains set correctly');
       $values = [
         'domain_id' => $domain->id(),
         'pattern' => array_shift($patterns),
@@ -56,7 +56,7 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
 
     // Visit the domain overview administration page.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Test the domains.
     $domains = $domain_storage->loadMultiple();
@@ -65,28 +65,28 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
     // Check the default domain.
     $default = $domain_storage->loadDefaultId();
     $key = 'example_com';
-    $this->assertTrue($default == $key, 'Default domain set correctly.');
+    $this->assertEquals($default, $key, 'Default domain set correctly.');
 
     // Test some text on the page.
     foreach ($domains as $domain) {
       $name = $domain->label();
-      $this->assertText($name, 'Name found properly.');
+      $this->assertSession()->pageTextContains($name, 'Name found properly.');
     }
     // Test the list of actions.
     $actions = ['delete', 'disable', 'default'];
     foreach ($actions as $action) {
-      $this->assertRaw("/domain/{$action}/", 'Actions found properly.');
+      $this->assertSession()->responseContains("/domain/{$action}/");
     }
     // Check that all domains are active.
-    $this->assertNoRaw('Inactive', 'Inactive domain not found.');
+    $this->assertSession()->responseNotContains('Inactive', 'Inactive domain not found.');
 
     // Disable a domain and test the enable link.
     $this->clickLink('Disable', 0);
-    $this->assertRaw('Inactive', 'Inactive domain found.');
+    $this->assertSession()->responseContains('Inactive');
 
     // Visit the domain overview administration page to clear cache.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     foreach ($domain_storage->loadMultiple() as $domain) {
       if ($domain->id() == 'one_example_com') {
@@ -100,15 +100,15 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
     // Test the list of actions.
     $actions = ['enable', 'delete', 'disable', 'default'];
     foreach ($actions as $action) {
-      $this->assertRaw("/domain/{$action}/", 'Actions found properly.');
+      $this->assertSession()->responseContains("/domain/{$action}/");
     }
     // Re-enable the domain.
     $this->clickLink('Enable', 0);
-    $this->assertNoRaw('Inactive', 'Inactive domain not found.');
+    $this->assertSession()->responseNotContains('Inactive');
 
     // Visit the domain overview administration page to clear cache.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     foreach ($domain_storage->loadMultiple() as $domain) {
       $this->assertNotEmpty($domain->status(), 'All domains active.');
@@ -119,17 +119,17 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
 
     // Visit the domain overview administration page to clear cache.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the default domain.
     $domain_storage->resetCache();
     $default = $domain_storage->loadDefaultId();
     $key = 'one_example_com';
-    $this->assertTrue($default == $key, 'Default domain set correctly.');
+    $this->assertEquals($default, $key, 'Default domain set correctly.');
 
     // Did the hostnames change accidentally?
     foreach ($domain_storage->loadMultiple() as $id => $domain) {
-      $this->assertTrue($domain->getHostname() == $original_domains[$id]->getHostname(), 'Hostnames match.');
+      $this->assertEquals($original_domains[$id]->getHostname(), $domain->getHostname(), 'Hostnames match.');
     }
 
   }

--- a/domain_alias/tests/src/Functional/DomainAliasActionsTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasActionsTest.php
@@ -14,7 +14,7 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias', 'user'];
+  protected static $modules = ['domain', 'domain_alias', 'user'];
 
   /**
    * Tests bulk actions through the domain overview page.
@@ -70,7 +70,7 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
     // Test some text on the page.
     foreach ($domains as $domain) {
       $name = $domain->label();
-      $this->assertSession()->pageTextContains($name, 'Name found properly.');
+      $this->assertSession()->pageTextContains($name);
     }
     // Test the list of actions.
     $actions = ['delete', 'disable', 'default'];
@@ -78,7 +78,7 @@ class DomainAliasActionsTest extends DomainAliasTestBase {
       $this->assertSession()->responseContains("/domain/{$action}/");
     }
     // Check that all domains are active.
-    $this->assertSession()->responseNotContains('Inactive', 'Inactive domain not found.');
+    $this->assertSession()->responseNotContains('Inactive');
 
     // Disable a domain and test the enable link.
     $this->clickLink('Disable', 0);

--- a/domain_alias/tests/src/Functional/DomainAliasEnvironmentTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasEnvironmentTest.php
@@ -49,27 +49,27 @@ class DomainAliasEnvironmentTest extends DomainAliasTestBase {
     }
     // Test the environment loader.
     $local = $alias_loader->loadByEnvironment('local');
-    $this->assert(count($local) == 3, 'Three aliases set to local');
+    $this->assertCount(3, $local, 'Three aliases set to local');
     // Test the environment matcher. $domain here is two.example.com.
     $match = $alias_loader->loadByEnvironmentMatch($domain, 'local');
-    $this->assert(count($match) == 1, 'One environment match loaded');
+    $this->assertCount(1, $match, 'One environment match loaded');
     $alias = current($match);
-    $this->assert($alias->getPattern() == 'five.' . $this->baseHostname, 'Proper pattern match loaded.');
+    $this->assertEquals('five.' . $this->baseHostname, $alias->getPattern(), 'Proper pattern match loaded.');
 
     // Set one alias to a different environment.
     $alias->set('environment', 'testing')->save();
     $local = $alias_loader->loadByEnvironment('local');
-    $this->assert(count($local) == 2, 'Two aliases set to local');
+    $this->assertCount(2, $local, 'Two aliases set to local');
     // Test the environment matcher. $domain here is two.example.com.
     $matches = $alias_loader->loadByEnvironmentMatch($domain, 'local');
-    $this->assert(count($matches) == 0, 'No environment matches loaded');
+    $this->assertCount(0, $matches, 'No environment matches loaded');
 
     // Test the environment matcher. $domain here is one.example.com.
     $domain = $domain_storage->load('one_example_com');
     $matches = $alias_loader->loadByEnvironmentMatch($domain, 'local');
-    $this->assert(count($matches) == 1, 'One environment match loaded');
+    $this->assertCount(1, $matches, 'One environment match loaded');
     $alias = current($matches);
-    $this->assert($alias->getPattern() == 'four.' . $this->baseHostname, 'Proper pattern match loaded.');
+    $this->assertEquals('four.' . $this->baseHostname, $alias->getPattern(), 'Proper pattern match loaded.');
 
     // Now load a page and check things.
     // Since we cannot read the service request, we place a block

--- a/domain_alias/tests/src/Functional/DomainAliasEnvironmentTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasEnvironmentTest.php
@@ -16,12 +16,12 @@ class DomainAliasEnvironmentTest extends DomainAliasTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias', 'user'];
+  protected static $modules = ['domain', 'domain_alias', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 3 domains. These will be example.com, one.example.com,

--- a/domain_alias/tests/src/Functional/DomainAliasListBuilderTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasListBuilderTest.php
@@ -65,7 +65,7 @@ class DomainAliasListBuilderTest extends DomainAliasTestBase {
     $user = $user_storage->load($account->id());
     $manager = \Drupal::service('domain.element_manager');
     $values = $manager->getFieldValues($user, DOMAIN_ADMIN_FIELD);
-    $this->assert(count($values) == 2, 'User saved with two domain records.');
+    $this->assertCount(2, $values, 'User saved with two domain records.');
 
     $this->drupalLogin($account);
 

--- a/domain_alias/tests/src/Functional/DomainAliasListBuilderTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasListBuilderTest.php
@@ -14,12 +14,12 @@ class DomainAliasListBuilderTest extends DomainAliasTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias', 'user'];
+  protected static $modules = ['domain', 'domain_alias', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain_alias/tests/src/Functional/DomainAliasListHostnameTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasListHostnameTest.php
@@ -12,7 +12,7 @@ class DomainAliasListHostnameTest extends DomainAliasTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 3 domains. These will be example.com, one.example.com,

--- a/domain_alias/tests/src/Functional/DomainAliasListHostnameTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasListHostnameTest.php
@@ -35,8 +35,8 @@ class DomainAliasListHostnameTest extends DomainAliasTestBase {
     $patterns = ['*.' . $base, 'four.' . $base, 'five.' . $base];
     $i = 0;
     foreach ($domains as $domain) {
-      $this->assert($domain->getHostname() == $hostnames[$i], 'Hostnames set correctly');
-      $this->assert($domain->getCanonical() == $hostnames[$i], 'Canonical domains set correctly');
+      $this->assertEquals($hostnames[$i], $domain->getHostname(), 'Hostnames set correctly');
+      $this->assertEquals($hostnames[$i], $domain->getCanonical(), 'Canonical domains set correctly');
       $values = [
         'domain_id' => $domain->id(),
         'pattern' => array_shift($patterns),
@@ -48,12 +48,12 @@ class DomainAliasListHostnameTest extends DomainAliasTestBase {
     }
     // Test the environment loader.
     $local = $alias_loader->loadByEnvironment('local');
-    $this->assert(count($local) == 3, 'Three aliases set to local');
+    $this->assertCount(3, $local, 'Three aliases set to local');
     // Test the environment matcher. $domain here is two.example.com.
     $match = $alias_loader->loadByEnvironmentMatch($domain, 'local');
-    $this->assert(count($match) == 1, 'One environment match loaded');
+    $this->assertCount(1, $match, 'One environment match loaded');
     $alias = current($match);
-    $this->assert($alias->getPattern() == 'five.' . $base, 'Proper pattern match loaded.');
+    $this->assertEquals('five.' . $base, $alias->getPattern(), 'Proper pattern match loaded.');
 
     $admin = $this->drupalCreateUser([
       'bypass node access',
@@ -74,8 +74,8 @@ class DomainAliasListHostnameTest extends DomainAliasTestBase {
     $i = 0;
     $domains = $domain_storage->loadMultiple();
     foreach ($domains as $domain) {
-      $this->assert($domain->getHostname() == $hostnames[$i], 'Hostnames set correctly');
-      $this->assert($domain->getCanonical() == $hostnames[$i], 'Canonical domains set correctly');
+      $this->assertEquals($hostnames[$i], $domain->getHostname(), 'Hostnames set correctly');
+      $this->assertEquals($hostnames[$i], $domain->getCanonical(), 'Canonical domains set correctly');
       $i++;
     }
   }

--- a/domain_alias/tests/src/Functional/DomainAliasNegotiatorTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasNegotiatorTest.php
@@ -16,7 +16,7 @@ class DomainAliasNegotiatorTest extends DomainAliasTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias', 'user', 'block'];
+  protected static $modules = ['domain', 'domain_alias', 'user', 'block'];
 
   /**
    * Tests the handling of aliased requests.

--- a/domain_alias/tests/src/Functional/DomainAliasNegotiatorTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasNegotiatorTest.php
@@ -48,8 +48,8 @@ class DomainAliasNegotiatorTest extends DomainAliasTestBase {
     foreach ($domain_storage->loadMultiple() as $domain) {
       $alias_domains[] = $domain;
       $this->drupalGet($domain->getPath());
-      $this->assertRaw($domain->label(), 'Loaded the proper domain.');
-      $this->assertRaw('Exact match', 'Direct domain match.');
+      $this->assertSession()->responseContains($domain->label());
+      $this->assertSession()->responseContains('Exact match');
     }
 
     // Now, test an alias for each domain.
@@ -65,9 +65,9 @@ class DomainAliasNegotiatorTest extends DomainAliasTestBase {
       $alias_domain->setPath();
       $url = $alias_domain->getPath();
       $this->drupalGet($url);
-      $this->assertRaw($alias_domain->label(), 'Loaded the proper domain.');
-      $this->assertRaw('ALIAS:', 'No direct domain match.');
-      $this->assertRaw($alias->getPattern(), 'Alias match.');
+      $this->assertSession()->responseContains($alias_domain->label());
+      $this->assertSession()->responseContains('ALIAS:');
+      $this->assertSession()->responseContains($alias->getPattern());
 
       // Test redirections.
       // @TODO: This could be much more elegant: the redirects break assertRaw()
@@ -90,9 +90,9 @@ class DomainAliasNegotiatorTest extends DomainAliasTestBase {
     $alias_domain->setPath();
     $url = $alias_domain->getPath();
     $this->drupalGet($url);
-    $this->assertRaw($alias_domain->label(), 'Loaded the proper domain.');
-    $this->assertRaw('ALIAS:', 'No direct domain match.');
-    $this->assertRaw($alias->getPattern(), 'Alias match.');
+    $this->assertSession()->responseContains($alias_domain->label());
+    $this->assertSession()->responseContains('ALIAS:');
+    $this->assertSession()->responseContains($alias->getPattern());
 
     // Test redirections.
     // @TODO: This could be much more elegant: the redirects break assertRaw()

--- a/domain_alias/tests/src/Functional/DomainAliasTestBase.php
+++ b/domain_alias/tests/src/Functional/DomainAliasTestBase.php
@@ -17,6 +17,6 @@ abstract class DomainAliasTestBase extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias'];
+  protected static $modules = ['domain', 'domain_alias'];
 
 }

--- a/domain_alias/tests/src/Functional/DomainAliasWildcardTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasWildcardTest.php
@@ -16,12 +16,12 @@ class DomainAliasWildcardTest extends DomainAliasTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias', 'user'];
+  protected static $modules = ['domain', 'domain_alias', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 3 domains. These will be example.com, one.example.com,

--- a/domain_alias/tests/src/Functional/DomainAliasWildcardTest.php
+++ b/domain_alias/tests/src/Functional/DomainAliasWildcardTest.php
@@ -49,19 +49,19 @@ class DomainAliasWildcardTest extends DomainAliasTestBase {
     }
     // Test the environment loader.
     $local = $alias_loader->loadByEnvironment('local');
-    $this->assert(count($local) == 3, 'Three aliases set to local');
+    $this->assertCount(3, $local, 'Three aliases set to local');
     // Test the environment matcher. $domain here is two.example.com.
     $match = $alias_loader->loadByEnvironmentMatch($domain, 'local');
-    $this->assert(count($match) == 1, 'One environment match loaded');
+    $this->assertCount(1, $match, 'One environment match loaded');
     $alias = current($match);
-    $this->assert($alias->getPattern() == 'five.example.*', 'Proper pattern match loaded.');
+    $this->assertEquals('five.example.*', $alias->getPattern(), 'Proper pattern match loaded.');
 
     // Test the environment matcher. $domain here is one.example.com.
     $domain = $domain_storage->load('one_example_com');
     $matches = $alias_loader->loadByEnvironmentMatch($domain, 'local');
-    $this->assert(count($matches) == 1, 'One environment match loaded');
+    $this->assertCount(1, $matches, 'One environment match loaded');
     $alias = current($matches);
-    $this->assert($alias->getPattern() == 'four.example.*', 'Proper pattern match loaded.');
+    $this->assertEquals('four.example.*', $alias->getPattern(), 'Proper pattern match loaded.');
 
     // Now load a page and check things.
     // Since we cannot read the service request, we place a block

--- a/domain_alias/tests/src/Kernel/DomainAliasDomainDeleteTest.php
+++ b/domain_alias/tests/src/Kernel/DomainAliasDomainDeleteTest.php
@@ -19,7 +19,7 @@ class DomainAliasDomainDeleteTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_alias'];
+  protected static $modules = ['domain', 'domain_alias'];
 
   /**
    * The Domain storage handler service.
@@ -38,7 +38,7 @@ class DomainAliasDomainDeleteTest extends DomainTestBase {
   /**
    * Test setup.
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create a domain.

--- a/domain_config/tests/src/Functional/DomainConfigAlterHookTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigAlterHookTest.php
@@ -14,7 +14,7 @@ class DomainConfigAlterHookTest extends DomainConfigTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_config',
     'domain_config_test',
@@ -45,7 +45,7 @@ class DomainConfigAlterHookTest extends DomainConfigTestBase {
   /**
    * Test setup.
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create a domain.

--- a/domain_config/tests/src/Functional/DomainConfigHomepageTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHomepageTest.php
@@ -50,7 +50,7 @@ class DomainConfigHomepageTest extends DomainConfigTestBase {
       $expected = $domain->getPath() . $homepages[$domain->id()];
       $expected_home = $this->drupalGet($expected);
 
-      $this->assertTrue($home == $expected_home, 'Proper home page loaded (' . $domain->id() . ').');
+      $this->assertEquals($expected_home, $home, 'Proper home page loaded (' . $domain->id() . ').');
     }
   }
 

--- a/domain_config/tests/src/Functional/DomainConfigHomepageTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHomepageTest.php
@@ -11,7 +11,7 @@ use Drupal\user\RoleInterface;
  */
 class DomainConfigHomepageTest extends DomainConfigTestBase {
 
-  public static $modules = ['node', 'views'];
+  protected static $modules = ['node', 'views'];
 
   /**
    * Tests that domain-specific homepage loading works.

--- a/domain_config/tests/src/Functional/DomainConfigHookProblemTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHookProblemTest.php
@@ -12,7 +12,7 @@ class DomainConfigHookProblemTest extends DomainConfigHookTest {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     // Adds the domain_config module.
     'domain_config',
   ];

--- a/domain_config/tests/src/Functional/DomainConfigHookTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHookTest.php
@@ -14,7 +14,7 @@ class DomainConfigHookTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     // See module info file for description of what this module does.
     'domain_config_hook_test',

--- a/domain_config/tests/src/Functional/DomainConfigHookTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHookTest.php
@@ -38,7 +38,7 @@ class DomainConfigHookTest extends BrowserTestBase {
     $this->drupalGet('user/login');
     $user = $this->drupalCreateUser([]);
     $edit = ['name' => $user->getAccountName(), 'pass' => $user->passRaw];
-    $this->submitForm(NULL, $edit, t('Log in'));
+    $this->submitForm($edit, t('Log in'));
 
     $test = \Drupal::state()->get('domain_config_test__user_login', NULL);
     // When this test passes, it means domain_config_hook_test_user_login was

--- a/domain_config/tests/src/Functional/DomainConfigHookTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigHookTest.php
@@ -38,7 +38,7 @@ class DomainConfigHookTest extends BrowserTestBase {
     $this->drupalGet('user/login');
     $user = $this->drupalCreateUser([]);
     $edit = ['name' => $user->getAccountName(), 'pass' => $user->passRaw];
-    $this->drupalPostForm(NULL, $edit, t('Log in'));
+    $this->submitForm(NULL, $edit, t('Log in'));
 
     $test = \Drupal::state()->get('domain_config_test__user_login', NULL);
     // When this test passes, it means domain_config_hook_test_user_login was

--- a/domain_config/tests/src/Functional/DomainConfigOverriderTest.php
+++ b/domain_config/tests/src/Functional/DomainConfigOverriderTest.php
@@ -36,10 +36,10 @@ class DomainConfigOverriderTest extends DomainConfigTestBase {
         $path = $domain->getPath() . $langcode . '/user/login';
         $this->drupalGet($path);
         if ($domain->isDefault()) {
-          $this->assertRaw('<title>Log in | Drupal</title>', 'Loaded the proper site name.');
+          $this->assertSession()->responseContains('<title>Log in | Drupal</title>');
         }
         else {
-          $this->assertRaw('<title>Log in | ' . $this->expectedName($domain, $langcode) . '</title>', 'Loaded the proper site name.' . '<title>Log in | ' . $this->expectedName($domain, $langcode) . '</title>');
+          $this->assertSession()->responseContains('<title>Log in | ' . $this->expectedName($domain, $langcode) . '</title>');
         }
       }
     }
@@ -67,11 +67,11 @@ class DomainConfigOverriderTest extends DomainConfigTestBase {
 
     $domain_one = $domains['one_example_com'];
     $this->drupalGet($domain_one->getPath() . 'user/login');
-    $this->assertRaw('<title>Log in | First</title>', 'Found overridden slogan for one.example.com.');
+    $this->assertSession()->responseContains('<title>Log in | First</title>');
 
     $domain_four = $domains['four_example_com'];
     $this->drupalGet($domain_four->getPath() . 'user/login');
-    $this->assertRaw('<title>Log in | Four overridden in settings</title>', 'Found overridden slogan for four.example.com.');
+    $this->assertSession()->responseContains('<title>Log in | Four overridden in settings</title>');
   }
 
   /**

--- a/domain_config/tests/src/Functional/DomainConfigTestBase.php
+++ b/domain_config/tests/src/Functional/DomainConfigTestBase.php
@@ -33,7 +33,7 @@ abstract class DomainConfigTestBase extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'language',
     'domain_config_test',
@@ -43,7 +43,7 @@ abstract class DomainConfigTestBase extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create and login user.

--- a/domain_config/tests/src/Functional/DomainConfigTestBase.php
+++ b/domain_config/tests/src/Functional/DomainConfigTestBase.php
@@ -54,11 +54,11 @@ abstract class DomainConfigTestBase extends DomainTestBase {
     $edit = [
       'predefined_langcode' => 'es',
     ];
-    $this->drupalPostForm('admin/config/regional/language/add', $edit, t('Add language'));
+    $this->submitForm('admin/config/regional/language/add', $edit, t('Add language'));
 
     // Enable URL language detection and selection.
     $edit = ['language_interface[enabled][language-url]' => '1'];
-    $this->drupalPostForm('admin/config/regional/language/detection', $edit, t('Save settings'));
+    $this->submitForm('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     $this->drupalLogout();
 

--- a/domain_config/tests/src/Functional/DomainConfigTestBase.php
+++ b/domain_config/tests/src/Functional/DomainConfigTestBase.php
@@ -54,11 +54,13 @@ abstract class DomainConfigTestBase extends DomainTestBase {
     $edit = [
       'predefined_langcode' => 'es',
     ];
-    $this->submitForm('admin/config/regional/language/add', $edit, t('Add language'));
+    $this->drupalGet('admin/config/regional/language/add');
+    $this->submitForm($edit, t('Add language'));
 
     // Enable URL language detection and selection.
+    $this->drupalGet('admin/config/regional/language/detection');
     $edit = ['language_interface[enabled][language-url]' => '1'];
-    $this->submitForm('admin/config/regional/language/detection', $edit, t('Save settings'));
+    $this->submitForm($edit, t('Save settings'));
 
     $this->drupalLogout();
 

--- a/domain_config_ui/tests/src/Functional/DomainConfigUIOptionsTest.php
+++ b/domain_config_ui/tests/src/Functional/DomainConfigUIOptionsTest.php
@@ -19,14 +19,14 @@ class DomainConfigUIOptionsTest extends DomainConfigTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain_config_ui',
   ];
 
   /**
    * {@inheritDoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->createAdminUser();

--- a/domain_config_ui/tests/src/Functional/DomainConfigUIOptionsTest.php
+++ b/domain_config_ui/tests/src/Functional/DomainConfigUIOptionsTest.php
@@ -49,11 +49,11 @@ class DomainConfigUIOptionsTest extends DomainConfigTestBase {
 
     // Visit the domain config ui administration page.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Visit the site information page.
     $this->drupalGet($path2);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     $this->findField('domain');
     $this->findField('language');
 
@@ -61,16 +61,16 @@ class DomainConfigUIOptionsTest extends DomainConfigTestBase {
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
-      $this->assertRaw($string, 'Found the domain option.');
+      $this->assertSession()->responseContains($string);
     }
     // We expect to find 'All Domains'.
-    $this->assertRaw('All Domains</option>', 'Found the domain option.');
+    $this->assertSession()->responseContains('All Domains</option>');
 
     // We expect to find two language options.
     $languages = ['en', 'es'];
     foreach ($languages as $langcode) {
       $string = 'value="' . $langcode . '"';
-      $this->assertRaw($string, 'Found the language option.');
+      $this->assertSession()->responseContains($string);
     }
 
     // Now test the editorUser.
@@ -78,11 +78,11 @@ class DomainConfigUIOptionsTest extends DomainConfigTestBase {
 
     // Visit the domain config ui administration page.
     $this->drupalGet($path);
-    $this->assertResponse(403);
+    $this->assertSession()->statusCodeEquals(403);
 
     // Visit the site information page.
     $this->drupalGet($path2);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     $this->findField('domain');
     $this->findNoField('language');
 
@@ -90,26 +90,26 @@ class DomainConfigUIOptionsTest extends DomainConfigTestBase {
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
       if (in_array($domain->id(), ['example_com', 'one_example_com'], TRUE)) {
-        $this->assertRaw($string, 'Found the domain option.');
+        $this->assertSession()->responseContains($string);
       }
       else {
-        $this->assertNoRaw($string, 'Did not find the domain option.');
+        $this->assertSession()->responseNotContains($string);
       }
     }
 
     // We expect to find 'All Domains'.
-    $this->assertRaw('All Domains</option>', 'Found the domain option.');
+    $this->assertSession()->responseContains('All Domains</option>');
 
     // Now test the languageUser.
     $this->drupalLogin($this->languageUser);
 
     // Visit the domain config ui administration page.
     $this->drupalGet($path);
-    $this->assertResponse(403);
+    $this->assertSession()->statusCodeEquals(403);
 
     // Visit the site information page.
     $this->drupalGet($path2);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     $this->findField('domain');
     $this->findField('language');
 
@@ -117,21 +117,21 @@ class DomainConfigUIOptionsTest extends DomainConfigTestBase {
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
       if (in_array($domain->id(), ['two_example_com', 'three_example_com'], TRUE)) {
-        $this->assertRaw($string, 'Found the domain option.');
+        $this->assertSession()->responseContains($string);
       }
       else {
-        $this->assertNoRaw($string, 'Did not find the domain option.');
+        $this->assertSession()->responseNotContains($string);
       }
     }
 
     // We do not expect to find 'All Domains'.
-    $this->assertNoRaw('All Domains</option>', 'Found the domain option.');
+    $this->assertSession()->responseNotContains('All Domains</option>');
 
     // We expect to find two language options.
     $languages = ['en', 'es'];
     foreach ($languages as $langcode) {
       $string = 'value="' . $langcode . '"';
-      $this->assertRaw($string, 'Found the language option.');
+      $this->assertSession()->responseContains($string);
     }
 
   }

--- a/domain_config_ui/tests/src/Functional/DomainConfigUIPermissionsTest.php
+++ b/domain_config_ui/tests/src/Functional/DomainConfigUIPermissionsTest.php
@@ -19,14 +19,14 @@ class DomainConfigUIPermissionsTest extends DomainConfigTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain_config_ui',
   ];
 
   /**
    * {@inheritDoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->createAdminUser();

--- a/domain_config_ui/tests/src/Functional/DomainConfigUIPermissionsTest.php
+++ b/domain_config_ui/tests/src/Functional/DomainConfigUIPermissionsTest.php
@@ -45,22 +45,22 @@ class DomainConfigUIPermissionsTest extends DomainConfigTestBase {
 
     // Visit the domain config ui administration page.
     $this->drupalGet($path);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Visit the site information page.
     $this->drupalGet($path2);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     $this->findField('domain');
 
     $this->drupalLogin($this->editorUser);
 
     // Visit the domain config ui administration page.
     $this->drupalGet($path);
-    $this->assertResponse(403);
+    $this->assertSession()->statusCodeEquals(403);
 
     // Visit the site information page.
     $this->drupalGet($path2);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     $this->findNoField('domain');
   }
 

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUIOverrideTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUIOverrideTest.php
@@ -39,7 +39,7 @@ class DomainConfigUIOverrideTest extends WebDriverTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain_config_ui',
     'domain_config_test',
     'language',
@@ -48,7 +48,7 @@ class DomainConfigUIOverrideTest extends WebDriverTestBase {
   /**
    * {@inheritDoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->createAdminUser();

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUIOverrideTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUIOverrideTest.php
@@ -155,11 +155,13 @@ class DomainConfigUIOverrideTest extends WebDriverTestBase {
     $edit = [
       'predefined_langcode' => 'es',
     ];
-    $this->submitForm('admin/config/regional/language/add', $edit, t('Add language'));
+    $this->drupalGet('admin/config/regional/language/add');
+    $this->submitForm($edit, t('Add language'));
 
     // Enable URL language detection and selection.
     $edit = ['language_interface[enabled][language-url]' => '1'];
-    $this->submitForm('admin/config/regional/language/detection', $edit, t('Save settings'));
+    $this->drupalGet('admin/config/regional/language/detection');
+    $this->submitForm($edit, t('Save settings'));
 
     $this->drupalLogout();
 
@@ -168,7 +170,7 @@ class DomainConfigUIOverrideTest extends WebDriverTestBase {
     $this->rebuildContainer();
 
     $es = \Drupal::entityTypeManager()->getStorage('configurable_language')->load('es');
-    $this->assertTrue(!empty($es), 'Created test language.');
+    $this->assertNotEmpty($es, 'Created test language.');
   }
 
 }

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUIOverrideTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUIOverrideTest.php
@@ -155,11 +155,11 @@ class DomainConfigUIOverrideTest extends WebDriverTestBase {
     $edit = [
       'predefined_langcode' => 'es',
     ];
-    $this->drupalPostForm('admin/config/regional/language/add', $edit, t('Add language'));
+    $this->submitForm('admin/config/regional/language/add', $edit, t('Add language'));
 
     // Enable URL language detection and selection.
     $edit = ['language_interface[enabled][language-url]' => '1'];
-    $this->drupalPostForm('admin/config/regional/language/detection', $edit, t('Save settings'));
+    $this->submitForm('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     $this->drupalLogout();
 

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUISettingsTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUISettingsTest.php
@@ -40,7 +40,7 @@ class DomainConfigUISettingsTest extends WebDriverTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain_config_ui',
     'language',
   ];
@@ -48,7 +48,7 @@ class DomainConfigUISettingsTest extends WebDriverTestBase {
   /**
    * {@inheritDoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->createAdminUser();

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUiSavedConfigTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUiSavedConfigTest.php
@@ -39,7 +39,7 @@ class DomainConfigUiSavedConfigTest extends WebDriverTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain_config_ui',
     'language',
   ];
@@ -47,7 +47,7 @@ class DomainConfigUiSavedConfigTest extends WebDriverTestBase {
   /**
    * {@inheritDoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->createAdminUser();

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUiSavedConfigTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUiSavedConfigTest.php
@@ -162,11 +162,13 @@ class DomainConfigUiSavedConfigTest extends WebDriverTestBase {
     $edit = [
       'predefined_langcode' => 'es',
     ];
-    $this->submitForm('admin/config/regional/language/add', $edit, t('Add language'));
+    $this->drupalGet('admin/config/regional/language/add');
+    $this->submitForm($edit, t('Add language'));
 
     // Enable URL language detection and selection.
     $edit = ['language_interface[enabled][language-url]' => '1'];
-    $this->submitForm('admin/config/regional/language/detection', $edit, t('Save settings'));
+    $this->drupalGet('admin/config/regional/language/detection');
+    $this->submitForm($edit, t('Save settings'));
 
     $this->drupalLogout();
 

--- a/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUiSavedConfigTest.php
+++ b/domain_config_ui/tests/src/FunctionalJavascript/DomainConfigUiSavedConfigTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\domain_config_ui\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\language\ConfigurableLanguageInterface;
 use Drupal\Tests\domain_config_ui\Traits\DomainConfigUITestTrait;
 use Drupal\Tests\domain\Traits\DomainTestTrait;
 
@@ -161,11 +162,11 @@ class DomainConfigUiSavedConfigTest extends WebDriverTestBase {
     $edit = [
       'predefined_langcode' => 'es',
     ];
-    $this->drupalPostForm('admin/config/regional/language/add', $edit, t('Add language'));
+    $this->submitForm('admin/config/regional/language/add', $edit, t('Add language'));
 
     // Enable URL language detection and selection.
     $edit = ['language_interface[enabled][language-url]' => '1'];
-    $this->drupalPostForm('admin/config/regional/language/detection', $edit, t('Save settings'));
+    $this->submitForm('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     $this->drupalLogout();
 
@@ -174,7 +175,7 @@ class DomainConfigUiSavedConfigTest extends WebDriverTestBase {
     $this->rebuildContainer();
 
     $es = \Drupal::entityTypeManager()->getStorage('configurable_language')->load('es');
-    $this->assertTrue(!empty($es), 'Created test language.');
+    $this->assertInstanceOf(ConfigurableLanguageInterface::class, $es, 'Created test language.');
   }
 
 }

--- a/domain_content/tests/src/Functional/DomainContentActionsTest.php
+++ b/domain_content/tests/src/Functional/DomainContentActionsTest.php
@@ -47,7 +47,7 @@ class DomainContentActionsTest extends DomainContentTestBase {
       'node_bulk_form[1]' => TRUE,
       'action' => 'domain_access_add_action.two_example_com',
     ];
-    $this->submitForm(NULL, $edit, t('Apply to selected items'));
+    $this->submitForm($edit, t('Apply to selected items'));
 
     // Both domains should be present.
     $this->assertSession()->responseContains($old_domain->label() . '</a>');
@@ -59,7 +59,7 @@ class DomainContentActionsTest extends DomainContentTestBase {
       'node_bulk_form[1]' => TRUE,
       'action' => 'domain_access_remove_action.two_example_com',
     ];
-    $this->submitForm(NULL, $edit, t('Apply to selected items'));
+    $this->submitForm($edit, t('Apply to selected items'));
 
     // Domains are linked properly in the output.
     $this->assertSession()->responseContains($old_domain->label() . '</a>');
@@ -73,7 +73,7 @@ class DomainContentActionsTest extends DomainContentTestBase {
       'node_bulk_form[0]' => TRUE,
       'action' => 'domain_access_none_action',
     ];
-    $this->submitForm(NULL, $edit, t('Apply to selected items'));
+    $this->submitForm($edit, t('Apply to selected items'));
 
     // There should be four elements.
     $this->assertSession()->responseContains('node_bulk_form[3]');

--- a/domain_content/tests/src/Functional/DomainContentActionsTest.php
+++ b/domain_content/tests/src/Functional/DomainContentActionsTest.php
@@ -38,8 +38,8 @@ class DomainContentActionsTest extends DomainContentTestBase {
     $new_domain = $this->domains['two_example_com'];
 
     // Domains are linked in the output.
-    $this->assertRaw($old_domain->label() . '</a>');
-    $this->assertNoRaw($new_domain->label() . '</a>');
+    $this->assertSession()->responseContains($old_domain->label() . '</a>');
+    $this->assertSession()->responseNotContains($new_domain->label() . '</a>');
 
     // Add some content to domain two.
     $edit = [
@@ -47,11 +47,11 @@ class DomainContentActionsTest extends DomainContentTestBase {
       'node_bulk_form[1]' => TRUE,
       'action' => 'domain_access_add_action.two_example_com',
     ];
-    $this->drupalPostForm(NULL, $edit, t('Apply to selected items'));
+    $this->submitForm(NULL, $edit, t('Apply to selected items'));
 
     // Both domains should be present.
-    $this->assertRaw($old_domain->label() . '</a>');
-    $this->assertRaw($new_domain->label() . '</a>');
+    $this->assertSession()->responseContains($old_domain->label() . '</a>');
+    $this->assertSession()->responseContains($new_domain->label() . '</a>');
 
     // Remove some content from domain two.
     $edit = [
@@ -59,25 +59,25 @@ class DomainContentActionsTest extends DomainContentTestBase {
       'node_bulk_form[1]' => TRUE,
       'action' => 'domain_access_remove_action.two_example_com',
     ];
-    $this->drupalPostForm(NULL, $edit, t('Apply to selected items'));
+    $this->submitForm(NULL, $edit, t('Apply to selected items'));
 
     // Domains are linked properly in the output.
-    $this->assertRaw($old_domain->label() . '</a>');
-    $this->assertNoRaw($new_domain->label() . '</a>');
+    $this->assertSession()->responseContains($old_domain->label() . '</a>');
+    $this->assertSession()->responseNotContains($new_domain->label() . '</a>');
 
     // There should be five elements.
-    $this->assertRaw('node_bulk_form[4]');
+    $this->assertSession()->responseContains('node_bulk_form[4]');
 
     // Remove one from all affiliates.
     $edit = [
       'node_bulk_form[0]' => TRUE,
       'action' => 'domain_access_none_action',
     ];
-    $this->drupalPostForm(NULL, $edit, t('Apply to selected items'));
+    $this->submitForm(NULL, $edit, t('Apply to selected items'));
 
     // There should be four elements.
-    $this->assertRaw('node_bulk_form[3]');
-    $this->assertNoRaw('node_bulk_form[4]');
+    $this->assertSession()->responseContains('node_bulk_form[3]');
+    $this->assertSession()->responseNotContains('node_bulk_form[4]');
   }
 
 }

--- a/domain_content/tests/src/Functional/DomainContentCountTest.php
+++ b/domain_content/tests/src/Functional/DomainContentCountTest.php
@@ -36,7 +36,7 @@ class DomainContentCountTest extends DomainContentTestBase {
     // Test the overview pages.
     foreach ($urls as $url) {
       $content = $this->drupalGet($url);
-      $this->assertResponse(200);
+      $this->assertSession()->statusCodeEquals(200);
       // Find the links.
       $this->findLink('All affiliates');
       foreach ($this->domains as $id => $domain) {

--- a/domain_content/tests/src/Functional/DomainContentPermissionsTest.php
+++ b/domain_content/tests/src/Functional/DomainContentPermissionsTest.php
@@ -36,7 +36,7 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
     // Test the overview and domain-specific pages.
     foreach ($urls as $url) {
       $this->drupalGet($url);
-      $this->assertResponse(200);
+      $this->assertSession()->statusCodeEquals(200);
       // Find the links.
       $this->findLink('All affiliates');
       foreach ($this->domains as $id => $domain) {
@@ -45,12 +45,12 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
 
       // All affiliates link.
       $this->drupalGet($url . '/all_affiliates');
-      $this->assertResponse(200);
+      $this->assertSession()->statusCodeEquals(200);
 
       // Individual domain pages.
       foreach ($this->domains as $id => $domain) {
         $this->drupalGet($url . '/' . $id);
-        $this->assertResponse(200);
+        $this->assertSession()->statusCodeEquals(200);
       }
     }
     // This user should be able to see everything but all affiliates.
@@ -68,21 +68,21 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
     // Test the overview and domain-specific pages.
     foreach ($urls as $url) {
       $this->drupalGet($url);
-      $this->assertResponse(200);
+      $this->assertSession()->statusCodeEquals(200);
       // Find the links.
-      $this->assertNoRaw('All affiliates');
+      $this->assertSession()->responseNotContains('All affiliates');
       foreach ($this->domains as $id => $domain) {
         $this->findLink($domain->label());
       }
 
       // All affiliates link.
       $this->drupalGet($url . '/all_affiliates');
-      $this->assertResponse(403);
+      $this->assertSession()->statusCodeEquals(403);
 
       // Individual domain pages.
       foreach ($this->domains as $id => $domain) {
         $this->drupalGet($url . '/' . $id);
-        $this->assertResponse(200);
+        $this->assertSession()->statusCodeEquals(200);
       }
     }
 
@@ -103,9 +103,9 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
         $expected = 403;
       }
       $this->drupalGet($url);
-      $this->assertResponse($expected);
+      $this->assertSession()->statusCodeEquals($expected);
       // Find the links.
-      $this->assertNoRaw('All affiliates');
+      $this->assertSession()->responseNotContains('All affiliates');
       foreach ($this->domains as $id => $domain) {
         if ($expected == 200) {
           $this->findLink($domain->label());
@@ -117,12 +117,12 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
 
       // All affiliates link will fail for both paths.
       $this->drupalGet($url . '/all_affiliates');
-      $this->assertResponse(403);
+      $this->assertSession()->statusCodeEquals(403);
 
       // Individual domain pages.
       foreach ($this->domains as $id => $domain) {
         $this->drupalGet($url . '/' . $id);
-        $this->assertResponse($expected);
+        $this->assertSession()->statusCodeEquals($expected);
       }
     }
 
@@ -144,9 +144,9 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
         $expected = 403;
       }
       $this->drupalGet($url);
-      $this->assertResponse($expected);
+      $this->assertSession()->statusCodeEquals($expected);
       // Find the links.
-      $this->assertNoRaw('All affiliates');
+      $this->assertSession()->responseNotContains('All affiliates');
       foreach ($this->domains as $id => $domain) {
         if ($expected == 200 && $id == $assigned_id) {
           $this->findLink($domain->label());
@@ -158,16 +158,16 @@ class DomainContentPermissionsTest extends DomainContentTestBase {
 
       // All affiliates link will fail for both paths.
       $this->drupalGet($url . '/all_affiliates');
-      $this->assertResponse(403);
+      $this->assertSession()->statusCodeEquals(403);
 
       // Individual domain pages.
       foreach ($this->domains as $id => $domain) {
         $this->drupalGet($url . '/' . $id);
         if ($expected == 200 && $id == $assigned_id) {
-          $this->assertResponse(200);
+          $this->assertSession()->statusCodeEquals(200);
         }
         else {
-          $this->assertResponse(403);
+          $this->assertSession()->statusCodeEquals(403);
         }
       }
     }

--- a/domain_content/tests/src/Functional/DomainContentTestBase.php
+++ b/domain_content/tests/src/Functional/DomainContentTestBase.php
@@ -96,7 +96,7 @@ abstract class DomainContentTestBase extends DomainTestBase {
     $content = preg_replace('@>\\s+<@', '><', $content);
     $regex = '/' . preg_quote($text, '/') . '/ui';
     $message = sprintf('The text "%s" was found in the text of the current page.', $text);
-    $this->assert((bool) preg_match($regex, $content), $message);
+    $this->assertTrue((bool) preg_match($regex, $content), $message);
   }
 
 }

--- a/domain_content/tests/src/Functional/DomainContentTestBase.php
+++ b/domain_content/tests/src/Functional/DomainContentTestBase.php
@@ -14,7 +14,7 @@ abstract class DomainContentTestBase extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_content'];
+  protected static $modules = ['domain', 'domain_content'];
 
   /**
    * An array of domains.
@@ -26,7 +26,7 @@ abstract class DomainContentTestBase extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create five test domains.

--- a/domain_source/tests/src/Functional/DomainSourceContentUrlsTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceContentUrlsTest.php
@@ -17,12 +17,12 @@ class DomainSourceContentUrlsTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_access', 'domain_source', 'field', 'node', 'user'];
+  protected static $modules = ['domain', 'domain_access', 'domain_source', 'field', 'node', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 4 domains.

--- a/domain_source/tests/src/Functional/DomainSourceContentUrlsTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceContentUrlsTest.php
@@ -58,15 +58,15 @@ class DomainSourceContentUrlsTest extends DomainTestBase {
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromRoute');
+    $this->assertEquals($expected, $url, 'fromRoute');
 
     // Get the link using Url::fromUserInput()
     $url = Url::fromUserInput($uri_path, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUserInput');
+    $this->assertEquals($expected, $url, 'fromUserInput');
 
     // Get the link using Url::fromUri()
     $url = Url::fromUri($uri, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUri');
+    $this->assertEquals($expected, $url, 'fromUri');
 
     // Get the path processor service.
     $paths = \Drupal::service('domain_access.manager');
@@ -77,7 +77,7 @@ class DomainSourceContentUrlsTest extends DomainTestBase {
       'two_example_com' => $domains['two_example_com']->getPath() . 'node/1',
     ];
 
-    $this->assertTrue($expected == $urls);
+    $this->assertEquals($expected, $urls);
   }
 
 }

--- a/domain_source/tests/src/Functional/DomainSourceElementTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceElementTest.php
@@ -16,7 +16,7 @@ class DomainSourceElementTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_access',
     'domain_source',
@@ -28,7 +28,7 @@ class DomainSourceElementTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain_source/tests/src/Functional/DomainSourceElementTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceElementTest.php
@@ -96,7 +96,7 @@ class DomainSourceElementTest extends DomainTestBase {
 
     // Check the URL.
     $url = $this->geturl();
-    $this->assert(strpos($url, 'node/' . $nid . '/edit') === FALSE, 'Form submitted.');
+    $this->assertFalse(strpos($url, 'node/' . $nid . '/edit'), 'Form submitted.');
 
     // Edit the node.
     $this->drupalGet('node/' . $nid . '/edit');
@@ -111,7 +111,7 @@ class DomainSourceElementTest extends DomainTestBase {
 
     // Check the URL.
     $url = $this->geturl();
-    $this->assert(strpos($url, 'node/' . $nid . '/edit') > 0, 'Form not submitted.');
+    $this->assertTrue(strpos($url, 'node/' . $nid . '/edit') > 0, 'Form not submitted.');
 
     // Set the field properly and save again.
     $this->selectFieldOption($locator, 'one_example_com');
@@ -122,7 +122,7 @@ class DomainSourceElementTest extends DomainTestBase {
 
     // Check the URL.
     $url = $this->geturl();
-    $this->assert(strpos($url, 'node/' . $nid . '/edit') === FALSE, 'Form submitted.');
+    $this->assertFalse(strpos($url, 'node/' . $nid . '/edit'), 'Form submitted.');
 
     // Save with no source.
     // Edit the node.
@@ -138,7 +138,7 @@ class DomainSourceElementTest extends DomainTestBase {
 
     // Check the URL.
     $url = $this->geturl();
-    $this->assert(strpos($url, 'node/' . $nid . '/edit') === FALSE, 'Form submitted.');
+    $this->assertFalse(strpos($url, 'node/' . $nid . '/edit'), 'Form submitted.');
   }
 
   /**

--- a/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
@@ -96,7 +96,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     // Try to post a node, assigned to the second domain.
     $edit['title[0][value]'] = 'Test node';
     $edit['field_domain_source'] = $two;
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->submitForm($edit, 'Save');
     $this->assertSession()->statusCodeEquals(200);
     $node = $node_storage->load(1);
     // Check that the value is set.
@@ -111,7 +111,8 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     // Try to post a node, assigned to no domain.
     $edit['title[0][value]'] = 'Test node';
     $edit["field_domain_source"] = '_none';
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->drupalGet('node/add/article');
+    $this->submitForm($edit, 'Save');
     $this->assertSession()->statusCodeEquals(200);
     $node = $node_storage->load(2);
     // Check that the value is set.
@@ -131,7 +132,8 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
       'menu_options[main]' => 1,
       'menu_parent' => 'main:',
     ];
-    $this->submitForm('admin/structure/types/manage/article', $edit, t('Save content type'));
+    $this->drupalGet('admin/structure/types/manage/article');
+    $this->submitForm($edit, t('Save content type'));
 
     // Create a third node that is assigned to a menu.
     $edit = [
@@ -140,7 +142,8 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
       'menu[title]' => 'Test preview',
       'field_domain_source' => $two,
     ];
-    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->drupalGet('node/add/article');
+    $this->submitForm($edit, 'Save');
     // Test the URL against expectations, and the rendered menu link.
     $node = $node_storage->load(3);
     $url = $node->toUrl()->toString();
@@ -163,7 +166,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     $this->assertSession()->statusCodeEquals(200);
     // Try to post a node, assigned to no domain.
     $edit2['title[0][value]'] = 'Test node';
-    $this->submitForm('node/add/article', $edit2, 'Save');
+    $this->submitForm($edit2, 'Save');
     // Test the URL against expectations, and the rendered menu link.
     $node = $node_storage->load(4);
     $url = $node->toUrl()->toString();

--- a/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
@@ -39,17 +39,17 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
 
     // Visit the article field administration page.
     $this->drupalGet('admin/structure/types/manage/article/fields');
-    $this->assertResponse(200, 'Manage fields page sourceed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertText('Domain Source', 'Domain form field found.');
+    $this->assertSession()->pageTextContains('Domain Source');
 
     // Visit the article field display administration page.
     $this->drupalGet('admin/structure/types/manage/article/display');
-    $this->assertResponse(200, 'Manage field display page sourceed.');
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check for a domain field.
-    $this->assertText('Domain Source', 'Domain form field found.');
+    $this->assertSession()->pageTextContains('Domain Source');
   }
 
   /**
@@ -70,16 +70,16 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
 
     // Visit the article field display administration page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Check the new field exists on the page.
-    $this->assertText('Domain Source', 'Found the domain field instance.');
+    $this->assertSession()->pageTextContains('Domain Source');
 
     // We expect to find 5 domain options + none.
     $domains = \Drupal::entityTypeManager()->getStorage('domain')->loadMultiple();
     foreach ($domains as $domain) {
       $string = 'value="' . $domain->id() . '"';
-      $this->assertRaw($string, 'Found the domain option.');
+      $this->assertSession()->responseContains($string);
       if (!isset($one)) {
         $one = $domain->id();
         continue;
@@ -89,15 +89,15 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
         $two_path = $domain->getPath();
       }
     }
-    $this->assertRaw('value="_none"', 'Found the _none_ option.');
+    $this->assertSession()->responseContains('value="_none"');
 
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');
 
     // Try to post a node, assigned to the second domain.
     $edit['title[0][value]'] = 'Test node';
     $edit['field_domain_source'] = $two;
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
-    $this->assertResponse(200);
+    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
     $node = $node_storage->load(1);
     // Check that the value is set.
     $value = domain_source_get($node);
@@ -111,8 +111,8 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     // Try to post a node, assigned to no domain.
     $edit['title[0][value]'] = 'Test node';
     $edit["field_domain_source"] = '_none';
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
-    $this->assertResponse(200);
+    $this->submitForm('node/add/article', $edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
     $node = $node_storage->load(2);
     // Check that the value is set.
     $value = domain_source_get($node);
@@ -131,7 +131,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
       'menu_options[main]' => 1,
       'menu_parent' => 'main:',
     ];
-    $this->drupalPostForm('admin/structure/types/manage/article', $edit, t('Save content type'));
+    $this->submitForm('admin/structure/types/manage/article', $edit, t('Save content type'));
 
     // Create a third node that is assigned to a menu.
     $edit = [
@@ -140,7 +140,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
       'menu[title]' => 'Test preview',
       'field_domain_source' => $two,
     ];
-    $this->drupalPostForm('node/add/article', $edit, 'Save');
+    $this->submitForm('node/add/article', $edit, 'Save');
     // Test the URL against expectations, and the rendered menu link.
     $node = $node_storage->load(3);
     $url = $node->toUrl()->toString();
@@ -148,7 +148,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     $this->assertEquals($expected_url, $url, 'URL rewritten correctly.');
     // Load the page with a menu and check that link.
     $this->drupalGet('node/3');
-    $this->assertRaw('href="' . $url, 'Menu link rewritten correctly.');
+    $this->assertSession()->responseContains('href="' . $url);
 
     // Remove the field from the node type and make sure nothing breaks.
     // See https://www.drupal.org/node/2892612
@@ -160,10 +160,10 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
     }
     // Visit the article field display administration page.
     $this->drupalGet('node/add/article');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     // Try to post a node, assigned to no domain.
     $edit2['title[0][value]'] = 'Test node';
-    $this->drupalPostForm('node/add/article', $edit2, 'Save');
+    $this->submitForm('node/add/article', $edit2, 'Save');
     // Test the URL against expectations, and the rendered menu link.
     $node = $node_storage->load(4);
     $url = $node->toUrl()->toString();

--- a/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceEntityReferenceTest.php
@@ -16,7 +16,7 @@ class DomainSourceEntityReferenceTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'domain',
     'domain_source',
     'field',

--- a/domain_source/tests/src/Functional/DomainSourceExcludeTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceExcludeTest.php
@@ -17,12 +17,12 @@ class DomainSourceExcludeTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_source', 'field', 'node', 'user'];
+  protected static $modules = ['domain', 'domain_source', 'field', 'node', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 2 domains.

--- a/domain_source/tests/src/Functional/DomainSourceLanguageTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceLanguageTest.php
@@ -84,15 +84,15 @@ class DomainSourceLanguageTest extends DomainTestBase {
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromRoute');
+    $this->assertEquals($expected, $url, 'fromRoute');
 
     // Get the link using Url::fromUserInput()
     $url = Url::fromUserInput($uri_path, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUserInput');
+    $this->assertEquals($expected, $url, 'fromUserInput');
 
     // Get the link using Url::fromUri()
     $url = Url::fromUri($uri, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUri');
+    $this->assertEquals($expected, $url, 'fromUri');
 
     // Now test the same for the Arfrikaans translation.
     $path = 'node/1';
@@ -106,22 +106,22 @@ class DomainSourceLanguageTest extends DomainTestBase {
     $options = ['language' => $language];
 
     $translation = $node->getTranslation('af');
-    $this->assertTrue(domain_source_get($translation) == $id2, domain_source_get($translation));
+    $this->assertEquals($id2, domain_source_get($translation), domain_source_get($translation));
 
     // Because of path cache, we have to flush here.
     drupal_flush_all_caches();
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromRoute');
+    $this->assertEquals($expected, $url, 'fromRoute');
 
     // Get the link using Url::fromUserInput()
     $url = Url::fromUserInput($uri_path, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUserInput');
+    $this->assertEquals($expected, $url, 'fromUserInput');
 
     // Get the link using Url::fromUri()
     $url = Url::fromUri($uri, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUri');
+    $this->assertEquals($expected, $url, 'fromUri');
   }
 
 }

--- a/domain_source/tests/src/Functional/DomainSourceLanguageTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceLanguageTest.php
@@ -18,7 +18,7 @@ class DomainSourceLanguageTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'language',
     'content_translation',
     'domain',
@@ -31,7 +31,7 @@ class DomainSourceLanguageTest extends DomainTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 5 domains.

--- a/domain_source/tests/src/Functional/DomainSourceParameterTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceParameterTest.php
@@ -17,12 +17,12 @@ class DomainSourceParameterTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = array('domain', 'domain_source', 'domain_source_test', 'field', 'node', 'user');
+  protected static $modules = array('domain', 'domain_source', 'domain_source_test', 'field', 'node', 'user');
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 3 domains.

--- a/domain_source/tests/src/Functional/DomainSourceTrustedHostTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceTrustedHostTest.php
@@ -54,7 +54,7 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromRoute');
+    $this->assertTrue($expected, $url, 'fromRoute');
 
     // Set up two additional domains.
     $domain2 = $domains['two_example_com'];
@@ -67,7 +67,7 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
     $this->writeSettings($settings);
     // This URL should fail due to trusted host omission.
     $this->drupalGet($url);
-    $this->assertRaw('The provided host name is not valid for this server.');
+    $this->assertSession()->responseContains('The provided host name is not valid for this server.');
 
     // Now switch the node to a domain that is trusted.
     $node->{DOMAIN_SOURCE_FIELD} = $domain2->id();
@@ -76,9 +76,9 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
     $expected = $domain2->getPath() . $path;
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
     // Assert that the URL is what we expect.
-    $this->assertTrue($url == $expected, 'fromRoute');
+    $this->assertTrue($expected, $url, 'fromRoute');
     $this->drupalGet($url);
-    $this->assertResponse(200, 'Url is validated by trusted host settings.');
+    $this->assertSession()->statusCodeEquals(200);
   }
 
 }

--- a/domain_source/tests/src/Functional/DomainSourceTrustedHostTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceTrustedHostTest.php
@@ -17,12 +17,12 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_source', 'field', 'node', 'user'];
+  protected static $modules = ['domain', 'domain_source', 'field', 'node', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 3 domains.
@@ -54,7 +54,7 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($expected, $url, 'fromRoute');
+    $this->assertEquals($expected, $url, 'fromRoute');
 
     // Set up two additional domains.
     $domain2 = $domains['two_example_com'];
@@ -76,7 +76,7 @@ class DomainSourceTrustedHostTest extends DomainTestBase {
     $expected = $domain2->getPath() . $path;
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
     // Assert that the URL is what we expect.
-    $this->assertTrue($expected, $url, 'fromRoute');
+    $this->assertEquals($expected, $url, 'fromRoute');
     $this->drupalGet($url);
     $this->assertSession()->statusCodeEquals(200);
   }

--- a/domain_source/tests/src/Functional/DomainSourceUrlTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceUrlTest.php
@@ -17,12 +17,12 @@ class DomainSourceUrlTest extends DomainTestBase {
    *
    * @var array
    */
-  public static $modules = ['domain', 'domain_source', 'field', 'node', 'user'];
+  protected static $modules = ['domain', 'domain_source', 'field', 'node', 'user'];
 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create 2 domains.
@@ -56,15 +56,15 @@ class DomainSourceUrlTest extends DomainTestBase {
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($expected, $url, 'fromRoute');
+    $this->assertEquals($expected, $url, 'fromRoute');
 
     // Get the link using Url::fromUserInput()
     $url = Url::fromUserInput($uri_path, $options)->toString();
-    $this->assertTrue($expected, $url, 'fromUserInput');
+    $this->assertEquals($expected, $url, 'fromUserInput');
 
     // Get the link using Url::fromUri()
     $url = Url::fromUri($uri, $options)->toString();
-    $this->assertTrue($expected, $url, 'fromUri');
+    $this->assertEquals($expected, $url, 'fromUri');
   }
 
 }

--- a/domain_source/tests/src/Functional/DomainSourceUrlTest.php
+++ b/domain_source/tests/src/Functional/DomainSourceUrlTest.php
@@ -56,15 +56,15 @@ class DomainSourceUrlTest extends DomainTestBase {
 
     // Get the link using Url::fromRoute().
     $url = Url::fromRoute($route_name, $route_parameters, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromRoute');
+    $this->assertTrue($expected, $url, 'fromRoute');
 
     // Get the link using Url::fromUserInput()
     $url = Url::fromUserInput($uri_path, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUserInput');
+    $this->assertTrue($expected, $url, 'fromUserInput');
 
     // Get the link using Url::fromUri()
     $url = Url::fromUri($uri, $options)->toString();
-    $this->assertTrue($url == $expected, 'fromUri');
+    $this->assertTrue($expected, $url, 'fromUri');
   }
 
 }


### PR DESCRIPTION
This PR removes all the deprecated code in the test classes that will be removed in Drupal 10.

Change records: 
- [Overridden test methods require void return type hints](https://www.drupal.org/node/3114724)
- [$modules is now a protected property in tests](https://www.drupal.org/node/2909426)
- [drupalPostForm in functional tests is deprecated](https://www.drupal.org/node/3168858)
- [Simpletest's legacy assertion methods are deprecated](https://www.drupal.org/node/3129738)
- [Calls to WebAssert methods do not allow more arguments than those in the signature](https://www.drupal.org/node/3162537)